### PR TITLE
release: Phase 2 Build Adapters (0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `WebhookParser.processJob()` — plain push events to allowed branches (develop, master, release, etc.) now set `shouldBeProcessed = true`; previously only forced-push and PR events were gated through the allowlist
+- `CppAdapter.lint()` — added `--error-exitcode=1` to cppcheck so lint fails when cppcheck reports findings (previously always exited 0)
+
+### Added
+- `PipelineOrchestratorTest` — 3 focused tests covering adapter caching (`prepare()` called once for multiple build steps) and prepare() failure aborting build steps; 261 total tests
+
 ## [0.2.0] - 2026-04-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-19
+
+### Added
+- `NodeAdapter` — Node.js / npm / yarn / pnpm build adapter with lint, test, build steps
+- `GoAdapter` — Go modules adapter; runs `go vet`, `golangci-lint` (optional), `go test`, `go build`
+- `PhpAdapter` — PHP / Composer adapter; phpcs/php-l lint, phpunit test, composer install build
+- `PythonAdapter` — Python adapter with pip / poetry / uv auto-detection; ruff/flake8 lint, pytest test
+- `CSharpAdapter` — .NET adapter; `dotnet format --verify-no-changes` lint, `dotnet test`, `dotnet publish`
+- `RustAdapter` — Cargo adapter; `cargo clippy`, `cargo fmt --check`, `cargo test`, `cargo build --release`
+- `JavaAdapter` — Maven/Gradle auto-detection; checkstyle lint, mvn/gradle test and package
+- `CppAdapter` — CMake + make/ninja adapter; cppcheck lint, cmake configure + build
+- `GenericAdapter` — arbitrary shell-command adapter driven entirely by `ciorch.yml` config keys
+- 8 preset `vars/ciorch_*.groovy` entry points (node, go, java, php, python, csharp, rust, cpp)
+- 8 `resources/matrix/*-standard.yml` presets wired to the new adapters
+- All 9 adapters registered in `PipelineOrchestrator.BUILD_REGISTRY`
+- 105 new unit tests (232 total, all passing)
+
+### Fixed
+- `lint_command` config key now consistent snake_case across all adapters (was `lintCommand` in NodeAdapter)
+- `lint()` correctly returns `false` on failure (was silently returning `true` in NodeAdapter and PhpAdapter)
+- Null-context fallback in `test()` and `build()` now invokes the resolved command directly (was using `eval "$CIORCH_CMD"` without the env var set)
+- `PythonAdapter` resolves `python3` vs `python` at prepare-time and uses the detected binary as the test default
+- `PythonAdapter` pip no-op path no longer reports a false `dist/` artifact
+
+## [0.1.0] - 2026-04-19
+
 ### Added
 - Initial repository scaffold with directory structure and Gradle build tooling
 - `tests/unit/build.gradle` with JenkinsPipelineUnit 1.23 and Spock 2.3-groovy-3.0 dependencies
 - MIT License
-- README skeleton with platform status table and quick-start example
+- README with logo, platform status table, quick-start example, and full documentation suite
+- `io.ciorch.core`: `Version`, `SystemCall`, `Config`, `Notifier`, `PipelineOrchestrator`
+- `io.ciorch.git`: `EventType`, `BranchType`, `TaskType`, `GitEvent`, `WebhookParser`, `MatrixLoader`, `MatrixEvaluator`, `GitOperations`
+- `io.ciorch.build`: `BuildAdapter` interface, `DockerAdapter`
+- `io.ciorch.deploy`: `DeployAdapter` interface
+- `vars/ciorch.groovy` Jenkins shared library entry point
+- `resources/matrix/default-gitflow.yml`, `github-flow.yml`, `trunk-based.yml`
+- 81 unit tests (Spock + JenkinsPipelineUnit)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 8 preset `vars/ciorch_*.groovy` entry points (node, go, java, php, python, csharp, rust, cpp)
 - 8 `resources/matrix/*-standard.yml` presets wired to the new adapters
 - All 9 adapters registered in `PipelineOrchestrator.BUILD_REGISTRY`
-- 177 new unit tests (258 total, all passing)
+- 177 new unit tests (258 total verified by CI, up from 81 in 0.1.0)
 
 ### Fixed
 - `lint_command` config key now consistent snake_case across all adapters (was `lintCommand` in NodeAdapter)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 8 preset `vars/ciorch_*.groovy` entry points (node, go, java, php, python, csharp, rust, cpp)
 - 8 `resources/matrix/*-standard.yml` presets wired to the new adapters
 - All 9 adapters registered in `PipelineOrchestrator.BUILD_REGISTRY`
-- 105 new unit tests (232 total, all passing)
+- 177 new unit tests (258 total, all passing)
 
 ### Fixed
 - `lint_command` config key now consistent snake_case across all adapters (was `lintCommand` in NodeAdapter)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- `WebhookParser.processJob()` — plain push events to allowed branches (develop, master, release, etc.) now set `shouldBeProcessed = true`; previously only forced-push and PR events were gated through the allowlist
-- `CppAdapter.lint()` — added `--error-exitcode=1` to cppcheck so lint fails when cppcheck reports findings (previously always exited 0)
-
-### Added
-- `PipelineOrchestratorTest` — 3 focused tests covering adapter caching (`prepare()` called once for multiple build steps) and prepare() failure aborting build steps; 261 total tests
-
 ## [0.2.0] - 2026-04-19
 
 ### Added
 - `NodeAdapter` — Node.js / npm / yarn / pnpm build adapter with lint, test, build steps
 - `GoAdapter` — Go modules adapter; runs `go vet`, `golangci-lint` (optional), `go test`, `go build`
-- `PhpAdapter` — PHP / Composer adapter; phpcs/php-l lint, phpunit test, composer install build
+- `PhpAdapter` — PHP / Composer adapter; phpcs/php -l lint, phpunit test, composer install build
 - `PythonAdapter` — Python adapter with pip / poetry / uv auto-detection; ruff/flake8 lint, pytest test
 - `CSharpAdapter` — .NET adapter; `dotnet format --verify-no-changes` lint, `dotnet test`, `dotnet publish`
 - `RustAdapter` — Cargo adapter; `cargo clippy`, `cargo fmt --check`, `cargo test`, `cargo build --release`
@@ -30,8 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 8 `resources/matrix/*-standard.yml` presets wired to the new adapters
 - All 9 adapters registered in `PipelineOrchestrator.BUILD_REGISTRY`
 - 177 new unit tests (261 total verified by CI, up from 81 in 0.1.0)
+- `PipelineOrchestratorTest` — 3 focused tests covering adapter caching (`prepare()` called once per run) and prepare() failure aborting build steps
 
 ### Fixed
+- `WebhookParser.processJob()` — plain push events to allowed branches (develop, master, release, etc.) now set `shouldBeProcessed = true`; previously only forced-push and PR events were gated through the allowlist
+- `CppAdapter.lint()` — added `--error-exitcode=1` to cppcheck so lint fails when cppcheck reports findings (previously always exited 0)
+- Preset `vars/ciorch_*.groovy` entry points — inverted map merge order (`args + [adapter:'X']`) so the preset adapter key always wins over caller-supplied overrides
 - `lint_command` config key now consistent snake_case across all adapters (was `lintCommand` in NodeAdapter)
 - `lint()` correctly returns `false` on failure (was silently returning `true` in NodeAdapter and PhpAdapter)
 - Null-context fallback in `test()` and `build()` now invokes the resolved command directly (was using `eval "$CIORCH_CMD"` without the env var set)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 8 preset `vars/ciorch_*.groovy` entry points (node, go, java, php, python, csharp, rust, cpp)
 - 8 `resources/matrix/*-standard.yml` presets wired to the new adapters
 - All 9 adapters registered in `PipelineOrchestrator.BUILD_REGISTRY`
-- 177 new unit tests (258 total verified by CI, up from 81 in 0.1.0)
+- 177 new unit tests (261 total verified by CI, up from 81 in 0.1.0)
 
 ### Fixed
 - `lint_command` config key now consistent snake_case across all adapters (was `lintCommand` in NodeAdapter)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-19 (post-review fixes)
+
+### Fixed (post-review)
+- `PipelineOrchestrator` — pass `config.buildMap()` into `prepare()`, `lint()`, `test()`, and `build()` so adapter behavior is driven by `ciorch.yml` and Jenkinsfile overrides rather than an empty map
+- `vars/ciorch.groovy` — apply `lint_command`, `test_command`, `build_command`, and `*_version` keys from `args` into `Config` so preset-var overrides work end-to-end
+- `PhpAdapter.lint()` — replace GNU-only `xargs -r` with portable `find -exec sh -c 'for f do ...' sh {} +` so PHP lint works on macOS/BSD agents
+- `PipelineOrchestratorTest` — added `cleanup()` to remove the `"counting"` registry entry after each spec, preventing order-dependent test failures
+
 ## [0.2.0] - 2026-04-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-04-19 (post-review fixes)
-
-### Fixed (post-review)
-- `PipelineOrchestrator` — pass `config.buildMap()` into `prepare()`, `lint()`, `test()`, and `build()` so adapter behavior is driven by `ciorch.yml` and Jenkinsfile overrides rather than an empty map
-- `vars/ciorch.groovy` — apply `lint_command`, `test_command`, `build_command`, and `*_version` keys from `args` into `Config` so preset-var overrides work end-to-end
-- `PhpAdapter.lint()` — replace GNU-only `xargs -r` with portable `find -exec sh -c 'for f do ...' sh {} +` so PHP lint works on macOS/BSD agents
-- `PipelineOrchestratorTest` — added `cleanup()` to remove the `"counting"` registry entry after each spec, preventing order-dependent test failures
-
 ## [0.2.0] - 2026-04-19
 
 ### Added
@@ -32,11 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All 9 adapters registered in `PipelineOrchestrator.BUILD_REGISTRY`
 - 177 new unit tests (261 total verified by CI, up from 81 in 0.1.0)
 - `PipelineOrchestratorTest` — 3 focused tests covering adapter caching (`prepare()` called once per run) and prepare() failure aborting build steps
+- `Config.buildMap()` — accessor returning snake_case build config map for consistent adapter dispatch
 
 ### Fixed
 - `WebhookParser.processJob()` — plain push events to allowed branches (develop, master, release, etc.) now set `shouldBeProcessed = true`; previously only forced-push and PR events were gated through the allowlist
 - `CppAdapter.lint()` — added `--error-exitcode=1` to cppcheck so lint fails when cppcheck reports findings (previously always exited 0)
 - Preset `vars/ciorch_*.groovy` entry points — inverted map merge order (`args + [adapter:'X']`) so the preset adapter key always wins over caller-supplied overrides
+- `PipelineOrchestrator` — pass `config.buildMap()` into `prepare()`, `lint()`, `test()`, and `build()` so adapter behavior is driven by `ciorch.yml` and Jenkinsfile overrides
+- `vars/ciorch.groovy` — apply `lint_command`, `test_command`, `build_command`, and `*_version` keys from `args` into `Config` so preset-var overrides work end-to-end; normalize version keys to plain String to avoid GString lookup mismatches
+- `PhpAdapter.lint()` — replace GNU-only `xargs -r` with portable `find -exec sh -c 'for f do ...' sh {} +` so PHP lint works on macOS/BSD agents
 - `lint_command` config key now consistent snake_case across all adapters (was `lintCommand` in NodeAdapter)
 - `lint()` correctly returns `false` on failure (was silently returning `true` in NodeAdapter and PhpAdapter)
 - Null-context fallback in `test()` and `build()` now invokes the resolved command directly (was using `eval "$CIORCH_CMD"` without the env var set)

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
   <h1>ci-orchestrator</h1>
   <p>Multi-platform CI/CD orchestration library for Jenkins, GitHub Actions, GitLab CI, and Bitbucket Pipelines.<br/>Build any language stack. Deploy to any CMS or framework.</p>
 
-  [![Tests](https://img.shields.io/badge/tests-81%20passing-brightgreen)](#running-tests)
+  [![Tests](https://img.shields.io/badge/tests-232%20passing-brightgreen)](#running-tests)
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-  [![Phase](https://img.shields.io/badge/phase-1%20Jenkins%20Core-blue)](#platform-status)
+  [![Phase](https://img.shields.io/badge/phase-2%20Build%20Adapters-blue)](#platform-status)
   [![Groovy](https://img.shields.io/badge/Groovy-3.0-4298B8?logo=apache-groovy&logoColor=white)](https://groovy-lang.org/)
   [![Jenkins](https://img.shields.io/badge/Jenkins-2.x-D24939?logo=jenkins&logoColor=white)](https://www.jenkins.io/)
 </div>
@@ -112,15 +112,15 @@ The branching strategy YAML (`resources/matrix/default-gitflow.yml`) controls wh
 | Adapter | Language | Phase |
 |---|---|---|
 | `docker` | Generic Docker build | ✅ 1 |
-| `node` | Node.js / npm / yarn | 🔜 2 |
-| `php` | PHP / Composer | 🔜 2 |
-| `python` | Python / pip | 🔜 2 |
-| `go` | Go modules | 🔜 2 |
-| `java-maven` | Java + Maven | 🔜 2 |
-| `java-gradle` | Java + Gradle | 🔜 2 |
-| `dotnet` | .NET / C# | 🔜 2 |
-| `rust` | Rust / Cargo | 🔜 2 |
-| `cpp` | C/C++ / CMake | 🔜 2 |
+| `node` | Node.js / npm / yarn | ✅ 2 |
+| `php` | PHP / Composer | ✅ 2 |
+| `python` | Python / pip / poetry / uv | ✅ 2 |
+| `go` | Go modules | ✅ 2 |
+| `java` | Java + Maven / Gradle | ✅ 2 |
+| `csharp` | .NET / C# | ✅ 2 |
+| `rust` | Rust / Cargo | ✅ 2 |
+| `cpp` | C/C++ / CMake | ✅ 2 |
+| `generic` | Any (shell commands from config) | ✅ 2 |
 
 ## Supported Deploy Adapters
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The branching strategy YAML (`resources/matrix/default-gitflow.yml`) controls wh
 | Adapter | Language | Phase |
 |---|---|---|
 | `docker` | Generic Docker build | ✅ 1 |
-| `node` | Node.js / npm / yarn | ✅ 2 |
+| `node` | Node.js / npm / yarn / pnpm | ✅ 2 |
 | `php` | PHP / Composer | ✅ 2 |
 | `python` | Python / pip / poetry / uv | ✅ 2 |
 | `go` | Go modules | ✅ 2 |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <h1>ci-orchestrator</h1>
   <p>Multi-platform CI/CD orchestration library for Jenkins, GitHub Actions, GitLab CI, and Bitbucket Pipelines.<br/>Build any language stack. Deploy to any CMS or framework.</p>
 
-  [![Tests](https://img.shields.io/badge/tests-232%20passing-brightgreen)](#running-tests)
+  [![Tests](https://img.shields.io/badge/tests-258%20passing-brightgreen)](#running-tests)
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
   [![Phase](https://img.shields.io/badge/phase-2%20Build%20Adapters-blue)](#platform-status)
   [![Groovy](https://img.shields.io/badge/Groovy-3.0-4298B8?logo=apache-groovy&logoColor=white)](https://groovy-lang.org/)
@@ -22,7 +22,7 @@ Instead of writing a `Jenkinsfile` from scratch for every project, you declare *
 - **Adapter pattern** — plug in any build toolchain (Node, PHP, Go, Java, Python, Rust, Docker…) or deploy target (WordPress, Drupal, Symfony, Django, FastAPI…) via a single interface.
 - **Shell-injection safe** — all external values are passed through `withEnv` + single-quoted shell variables, never interpolated into Groovy strings.
 - **Jenkins CPS compliant** — all classes implement `Serializable`; regex and split operations are annotated `@NonCPS`.
-- **Testable** — 81 unit tests (Spock + JenkinsPipelineUnit) run without a live Jenkins instance.
+- **Testable** — 258 unit tests (Spock + JenkinsPipelineUnit) run without a live Jenkins instance.
 - **Single config file** — `ciorch.yml` at repo root is read by every supported platform.
 
 ## Platform Status
@@ -140,7 +140,7 @@ The branching strategy YAML (`resources/matrix/default-gitflow.yml`) controls wh
 ./gradlew :tests:unit:test
 ```
 
-Tests use [JenkinsPipelineUnit](https://github.com/jenkinsci/JenkinsPipelineUnit) + [Spock](https://spockframework.org/) and run without a live Jenkins instance. 81 tests covering `Version`, `MatrixEvaluator`, `WebhookParser`, and `Config`.
+Tests use [JenkinsPipelineUnit](https://github.com/jenkinsci/JenkinsPipelineUnit) + [Spock](https://spockframework.org/) and run without a live Jenkins instance. 258 tests covering all adapters, `Version`, `MatrixEvaluator`, `WebhookParser`, and `Config`.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <h1>ci-orchestrator</h1>
   <p>Multi-platform CI/CD orchestration library for Jenkins, GitHub Actions, GitLab CI, and Bitbucket Pipelines.<br/>Build any language stack. Deploy to any CMS or framework.</p>
 
-  [![Tests](https://img.shields.io/badge/tests-258%20passing-brightgreen)](#running-tests)
+  [![Tests](https://img.shields.io/badge/tests-261%20passing-brightgreen)](#running-tests)
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
   [![Phase](https://img.shields.io/badge/phase-2%20Build%20Adapters-blue)](#platform-status)
   [![Groovy](https://img.shields.io/badge/Groovy-3.0-4298B8?logo=apache-groovy&logoColor=white)](https://groovy-lang.org/)
@@ -22,7 +22,7 @@ Instead of writing a `Jenkinsfile` from scratch for every project, you declare *
 - **Adapter pattern** — plug in any build toolchain (Node, PHP, Go, Java, Python, Rust, Docker…) or deploy target (WordPress, Drupal, Symfony, Django, FastAPI…) via a single interface.
 - **Shell-injection safe** — all external values are passed through `withEnv` + single-quoted shell variables, never interpolated into Groovy strings.
 - **Jenkins CPS compliant** — all classes implement `Serializable`; regex and split operations are annotated `@NonCPS`.
-- **Testable** — 258 unit tests (Spock + JenkinsPipelineUnit) run without a live Jenkins instance.
+- **Testable** — 261 unit tests (Spock + JenkinsPipelineUnit) run without a live Jenkins instance.
 - **Single config file** — `ciorch.yml` at repo root is read by every supported platform.
 
 ## Platform Status
@@ -140,7 +140,7 @@ The branching strategy YAML (`resources/matrix/default-gitflow.yml`) controls wh
 ./gradlew :tests:unit:test
 ```
 
-Tests use [JenkinsPipelineUnit](https://github.com/jenkinsci/JenkinsPipelineUnit) + [Spock](https://spockframework.org/) and run without a live Jenkins instance. 258 tests covering all adapters, `Version`, `MatrixEvaluator`, `WebhookParser`, and `Config`.
+Tests use [JenkinsPipelineUnit](https://github.com/jenkinsci/JenkinsPipelineUnit) + [Spock](https://spockframework.org/) and run without a live Jenkins instance. 261 tests covering all adapters, `Version`, `MatrixEvaluator`, `WebhookParser`, and `Config`.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Instead of writing a `Jenkinsfile` from scratch for every project, you declare *
 
 - **Data-driven pipelines** — branching rules are YAML, not code. Swap strategies (`gitflow`, `github-flow`, `trunk-based`) without touching your `Jenkinsfile`.
 - **Adapter pattern** — plug in any build toolchain (Node, PHP, Go, Java, Python, Rust, Docker…) or deploy target (WordPress, Drupal, Symfony, Django, FastAPI…) via a single interface.
-- **Shell-injection safe** — all external values are passed through `withEnv` + single-quoted shell variables, never interpolated into Groovy strings.
+- **Shell-injection aware** — external values are generally passed through `withEnv` + single-quoted shell variables; however, user-configured command overrides such as `lint_command`, `test_command`, and `build_command` are trusted config and executed verbatim when set.
 - **Jenkins CPS compliant** — all classes implement `Serializable`; regex and split operations are annotated `@NonCPS`.
 - **Testable** — 261 unit tests (Spock + JenkinsPipelineUnit) run without a live Jenkins instance.
 - **Single config file** — `ciorch.yml` at repo root is read by every supported platform.

--- a/resources/matrix/cpp-standard.yml
+++ b/resources/matrix/cpp-standard.yml
@@ -1,6 +1,6 @@
 # ci-orchestrator C++ standard branching matrix
-# Rules are evaluated top-to-bottom; first match wins.
-# Priority: higher number = evaluated first
+# Matching rules are selected by priority; higher numbers take precedence.
+# File order does not control evaluation.
 
 branch_patterns:
   feature: "^feature/"

--- a/resources/matrix/cpp-standard.yml
+++ b/resources/matrix/cpp-standard.yml
@@ -1,0 +1,76 @@
+# ci-orchestrator C++ standard branching matrix
+# Rules are evaluated top-to-bottom; first match wins.
+# Priority: higher number = evaluated first
+
+branch_patterns:
+  feature: "^feature/"
+  develop: "^develop$"
+  release: "^release/"
+  master:  "^(master|main)$"
+
+rules:
+  # ---- feature/* + open PR → lint + test ----
+
+  - id: "cpp-feature-open-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "opened"
+    tasks: [lint, test]
+    priority: 100
+
+  - id: "cpp-feature-sync-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "synchronize"
+    tasks: [lint, test]
+    priority: 99
+
+  # ---- develop + push → lint + test + build ----
+
+  - id: "cpp-develop-push"
+    src_branch: "develop"
+    dst_branch: "develop"
+    event: "push"
+    tasks: [lint, test, build]
+    priority: 90
+
+  - id: "cpp-develop-merged"
+    src_branch: null
+    dst_branch: "develop"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 89
+
+  # ---- release/* merged PR to main/master → lint + test + build ----
+
+  - id: "cpp-release-master-merged-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 80
+
+  - id: "cpp-release-master-open-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "opened"
+    tasks: [lint, test]
+    priority: 79
+
+  # ---- main/master + push → lint + test + build + deploy ----
+
+  - id: "cpp-master-push"
+    src_branch: "master"
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 70
+
+  - id: "cpp-main-push"
+    src_branch: null
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 69

--- a/resources/matrix/cpp-standard.yml
+++ b/resources/matrix/cpp-standard.yml
@@ -67,10 +67,3 @@ rules:
     event: "push"
     tasks: [lint, test, build, deploy]
     priority: 70
-
-  - id: "cpp-main-push"
-    src_branch: null
-    dst_branch: "master"
-    event: "push"
-    tasks: [lint, test, build, deploy]
-    priority: 69

--- a/resources/matrix/csharp-standard.yml
+++ b/resources/matrix/csharp-standard.yml
@@ -1,0 +1,76 @@
+# ci-orchestrator C# standard branching matrix
+# Rules are evaluated top-to-bottom; first match wins.
+# Priority: higher number = evaluated first
+
+branch_patterns:
+  feature: "^feature/"
+  develop: "^develop$"
+  release: "^release/"
+  master:  "^(master|main)$"
+
+rules:
+  # ---- feature/* + open PR → lint + test ----
+
+  - id: "csharp-feature-open-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "opened"
+    tasks: [lint, test]
+    priority: 100
+
+  - id: "csharp-feature-sync-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "synchronize"
+    tasks: [lint, test]
+    priority: 99
+
+  # ---- develop + push → lint + test + build ----
+
+  - id: "csharp-develop-push"
+    src_branch: "develop"
+    dst_branch: "develop"
+    event: "push"
+    tasks: [lint, test, build]
+    priority: 90
+
+  - id: "csharp-develop-merged"
+    src_branch: null
+    dst_branch: "develop"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 89
+
+  # ---- release/* merged PR to main/master → lint + test + build ----
+
+  - id: "csharp-release-master-merged-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 80
+
+  - id: "csharp-release-master-open-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "opened"
+    tasks: [lint, test]
+    priority: 79
+
+  # ---- main/master + push → lint + test + build + deploy ----
+
+  - id: "csharp-master-push"
+    src_branch: "master"
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 70
+
+  - id: "csharp-main-push"
+    src_branch: null
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 69

--- a/resources/matrix/csharp-standard.yml
+++ b/resources/matrix/csharp-standard.yml
@@ -1,6 +1,6 @@
 # ci-orchestrator C# standard branching matrix
-# Rules are evaluated top-to-bottom; first match wins.
-# Priority: higher number = evaluated first
+# Matching rules are selected by priority; higher numbers take precedence.
+# File order does not control evaluation.
 
 branch_patterns:
   feature: "^feature/"

--- a/resources/matrix/csharp-standard.yml
+++ b/resources/matrix/csharp-standard.yml
@@ -67,10 +67,3 @@ rules:
     event: "push"
     tasks: [lint, test, build, deploy]
     priority: 70
-
-  - id: "csharp-main-push"
-    src_branch: null
-    dst_branch: "master"
-    event: "push"
-    tasks: [lint, test, build, deploy]
-    priority: 69

--- a/resources/matrix/go-standard.yml
+++ b/resources/matrix/go-standard.yml
@@ -1,6 +1,6 @@
 # ci-orchestrator Go standard branching matrix
-# Rules are evaluated top-to-bottom; first match wins.
-# Priority: higher number = evaluated first
+# Matching rules are selected by priority; higher numbers take precedence.
+# File order does not control evaluation.
 
 branch_patterns:
   feature: "^feature/"

--- a/resources/matrix/go-standard.yml
+++ b/resources/matrix/go-standard.yml
@@ -1,0 +1,76 @@
+# ci-orchestrator Go standard branching matrix
+# Rules are evaluated top-to-bottom; first match wins.
+# Priority: higher number = evaluated first
+
+branch_patterns:
+  feature: "^feature/"
+  develop: "^develop$"
+  release: "^release/"
+  master:  "^(master|main)$"
+
+rules:
+  # ---- feature/* + open PR → lint + test ----
+
+  - id: "go-feature-open-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "opened"
+    tasks: [lint, test]
+    priority: 100
+
+  - id: "go-feature-sync-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "synchronize"
+    tasks: [lint, test]
+    priority: 99
+
+  # ---- develop + push → lint + test + build ----
+
+  - id: "go-develop-push"
+    src_branch: "develop"
+    dst_branch: "develop"
+    event: "push"
+    tasks: [lint, test, build]
+    priority: 90
+
+  - id: "go-develop-merged"
+    src_branch: null
+    dst_branch: "develop"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 89
+
+  # ---- release/* merged PR to main/master → lint + test + build ----
+
+  - id: "go-release-master-merged-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 80
+
+  - id: "go-release-master-open-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "opened"
+    tasks: [lint, test]
+    priority: 79
+
+  # ---- main/master + push → lint + test + build + deploy ----
+
+  - id: "go-master-push"
+    src_branch: "master"
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 70
+
+  - id: "go-main-push"
+    src_branch: null
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 69

--- a/resources/matrix/go-standard.yml
+++ b/resources/matrix/go-standard.yml
@@ -67,10 +67,3 @@ rules:
     event: "push"
     tasks: [lint, test, build, deploy]
     priority: 70
-
-  - id: "go-main-push"
-    src_branch: null
-    dst_branch: "master"
-    event: "push"
-    tasks: [lint, test, build, deploy]
-    priority: 69

--- a/resources/matrix/java-standard.yml
+++ b/resources/matrix/java-standard.yml
@@ -1,6 +1,6 @@
 # ci-orchestrator Java standard branching matrix
-# Rules are evaluated top-to-bottom; first match wins.
-# Priority: higher number = evaluated first
+# Matching rules are selected by priority; higher numbers take precedence.
+# File order does not control evaluation.
 
 branch_patterns:
   feature: "^feature/"

--- a/resources/matrix/java-standard.yml
+++ b/resources/matrix/java-standard.yml
@@ -1,0 +1,76 @@
+# ci-orchestrator Java standard branching matrix
+# Rules are evaluated top-to-bottom; first match wins.
+# Priority: higher number = evaluated first
+
+branch_patterns:
+  feature: "^feature/"
+  develop: "^develop$"
+  release: "^release/"
+  master:  "^(master|main)$"
+
+rules:
+  # ---- feature/* + open PR → lint + test ----
+
+  - id: "java-feature-open-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "opened"
+    tasks: [lint, test]
+    priority: 100
+
+  - id: "java-feature-sync-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "synchronize"
+    tasks: [lint, test]
+    priority: 99
+
+  # ---- develop + push → lint + test + build ----
+
+  - id: "java-develop-push"
+    src_branch: "develop"
+    dst_branch: "develop"
+    event: "push"
+    tasks: [lint, test, build]
+    priority: 90
+
+  - id: "java-develop-merged"
+    src_branch: null
+    dst_branch: "develop"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 89
+
+  # ---- release/* merged PR to main/master → lint + test + build ----
+
+  - id: "java-release-master-merged-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 80
+
+  - id: "java-release-master-open-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "opened"
+    tasks: [lint, test]
+    priority: 79
+
+  # ---- main/master + push → lint + test + build + deploy ----
+
+  - id: "java-master-push"
+    src_branch: "master"
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 70
+
+  - id: "java-main-push"
+    src_branch: null
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 69

--- a/resources/matrix/java-standard.yml
+++ b/resources/matrix/java-standard.yml
@@ -67,10 +67,3 @@ rules:
     event: "push"
     tasks: [lint, test, build, deploy]
     priority: 70
-
-  - id: "java-main-push"
-    src_branch: null
-    dst_branch: "master"
-    event: "push"
-    tasks: [lint, test, build, deploy]
-    priority: 69

--- a/resources/matrix/node-standard.yml
+++ b/resources/matrix/node-standard.yml
@@ -67,10 +67,3 @@ rules:
     event: "push"
     tasks: [lint, test, build, deploy]
     priority: 70
-
-  - id: "node-main-push"
-    src_branch: null
-    dst_branch: "master"
-    event: "push"
-    tasks: [lint, test, build, deploy]
-    priority: 69

--- a/resources/matrix/node-standard.yml
+++ b/resources/matrix/node-standard.yml
@@ -1,0 +1,76 @@
+# ci-orchestrator Node.js standard branching matrix
+# Rules are evaluated top-to-bottom; first match wins.
+# Priority: higher number = evaluated first
+
+branch_patterns:
+  feature: "^feature/"
+  develop: "^develop$"
+  release: "^release/"
+  master:  "^(master|main)$"
+
+rules:
+  # ---- feature/* + open PR → lint + test ----
+
+  - id: "node-feature-open-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "opened"
+    tasks: [lint, test]
+    priority: 100
+
+  - id: "node-feature-sync-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "synchronize"
+    tasks: [lint, test]
+    priority: 99
+
+  # ---- develop + push → lint + test + build ----
+
+  - id: "node-develop-push"
+    src_branch: "develop"
+    dst_branch: "develop"
+    event: "push"
+    tasks: [lint, test, build]
+    priority: 90
+
+  - id: "node-develop-merged"
+    src_branch: null
+    dst_branch: "develop"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 89
+
+  # ---- release/* merged PR to main/master → lint + test + build ----
+
+  - id: "node-release-master-merged-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 80
+
+  - id: "node-release-master-open-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "opened"
+    tasks: [lint, test]
+    priority: 79
+
+  # ---- main/master + push → lint + test + build + deploy ----
+
+  - id: "node-master-push"
+    src_branch: "master"
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 70
+
+  - id: "node-main-push"
+    src_branch: null
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 69

--- a/resources/matrix/node-standard.yml
+++ b/resources/matrix/node-standard.yml
@@ -1,6 +1,6 @@
 # ci-orchestrator Node.js standard branching matrix
-# Rules are evaluated top-to-bottom; first match wins.
-# Priority: higher number = evaluated first
+# Matching rules are selected by priority; higher numbers take precedence.
+# File order does not control evaluation.
 
 branch_patterns:
   feature: "^feature/"

--- a/resources/matrix/php-standard.yml
+++ b/resources/matrix/php-standard.yml
@@ -1,0 +1,76 @@
+# ci-orchestrator PHP standard branching matrix
+# Rules are evaluated top-to-bottom; first match wins.
+# Priority: higher number = evaluated first
+
+branch_patterns:
+  feature: "^feature/"
+  develop: "^develop$"
+  release: "^release/"
+  master:  "^(master|main)$"
+
+rules:
+  # ---- feature/* + open PR → lint + test ----
+
+  - id: "php-feature-open-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "opened"
+    tasks: [lint, test]
+    priority: 100
+
+  - id: "php-feature-sync-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "synchronize"
+    tasks: [lint, test]
+    priority: 99
+
+  # ---- develop + push → lint + test + build ----
+
+  - id: "php-develop-push"
+    src_branch: "develop"
+    dst_branch: "develop"
+    event: "push"
+    tasks: [lint, test, build]
+    priority: 90
+
+  - id: "php-develop-merged"
+    src_branch: null
+    dst_branch: "develop"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 89
+
+  # ---- release/* merged PR to main/master → lint + test + build ----
+
+  - id: "php-release-master-merged-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 80
+
+  - id: "php-release-master-open-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "opened"
+    tasks: [lint, test]
+    priority: 79
+
+  # ---- main/master + push → lint + test + build + deploy ----
+
+  - id: "php-master-push"
+    src_branch: "master"
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 70
+
+  - id: "php-main-push"
+    src_branch: null
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 69

--- a/resources/matrix/php-standard.yml
+++ b/resources/matrix/php-standard.yml
@@ -1,6 +1,6 @@
 # ci-orchestrator PHP standard branching matrix
-# Rules are evaluated top-to-bottom; first match wins.
-# Priority: higher number = evaluated first
+# Matching rules are selected by priority; higher numbers take precedence.
+# File order does not control evaluation.
 
 branch_patterns:
   feature: "^feature/"

--- a/resources/matrix/php-standard.yml
+++ b/resources/matrix/php-standard.yml
@@ -67,10 +67,3 @@ rules:
     event: "push"
     tasks: [lint, test, build, deploy]
     priority: 70
-
-  - id: "php-main-push"
-    src_branch: null
-    dst_branch: "master"
-    event: "push"
-    tasks: [lint, test, build, deploy]
-    priority: 69

--- a/resources/matrix/python-standard.yml
+++ b/resources/matrix/python-standard.yml
@@ -1,0 +1,76 @@
+# ci-orchestrator Python standard branching matrix
+# Rules are evaluated top-to-bottom; first match wins.
+# Priority: higher number = evaluated first
+
+branch_patterns:
+  feature: "^feature/"
+  develop: "^develop$"
+  release: "^release/"
+  master:  "^(master|main)$"
+
+rules:
+  # ---- feature/* + open PR → lint + test ----
+
+  - id: "python-feature-open-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "opened"
+    tasks: [lint, test]
+    priority: 100
+
+  - id: "python-feature-sync-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "synchronize"
+    tasks: [lint, test]
+    priority: 99
+
+  # ---- develop + push → lint + test + build ----
+
+  - id: "python-develop-push"
+    src_branch: "develop"
+    dst_branch: "develop"
+    event: "push"
+    tasks: [lint, test, build]
+    priority: 90
+
+  - id: "python-develop-merged"
+    src_branch: null
+    dst_branch: "develop"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 89
+
+  # ---- release/* merged PR to main/master → lint + test + build ----
+
+  - id: "python-release-master-merged-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 80
+
+  - id: "python-release-master-open-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "opened"
+    tasks: [lint, test]
+    priority: 79
+
+  # ---- main/master + push → lint + test + build + deploy ----
+
+  - id: "python-master-push"
+    src_branch: "master"
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 70
+
+  - id: "python-main-push"
+    src_branch: null
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 69

--- a/resources/matrix/python-standard.yml
+++ b/resources/matrix/python-standard.yml
@@ -1,6 +1,6 @@
 # ci-orchestrator Python standard branching matrix
-# Rules are evaluated top-to-bottom; first match wins.
-# Priority: higher number = evaluated first
+# Matching rules are selected by priority; higher numbers take precedence.
+# File order does not control evaluation.
 
 branch_patterns:
   feature: "^feature/"

--- a/resources/matrix/python-standard.yml
+++ b/resources/matrix/python-standard.yml
@@ -67,10 +67,3 @@ rules:
     event: "push"
     tasks: [lint, test, build, deploy]
     priority: 70
-
-  - id: "python-main-push"
-    src_branch: null
-    dst_branch: "master"
-    event: "push"
-    tasks: [lint, test, build, deploy]
-    priority: 69

--- a/resources/matrix/rust-standard.yml
+++ b/resources/matrix/rust-standard.yml
@@ -1,0 +1,76 @@
+# ci-orchestrator Rust standard branching matrix
+# Rules are evaluated top-to-bottom; first match wins.
+# Priority: higher number = evaluated first
+
+branch_patterns:
+  feature: "^feature/"
+  develop: "^develop$"
+  release: "^release/"
+  master:  "^(master|main)$"
+
+rules:
+  # ---- feature/* + open PR → lint + test ----
+
+  - id: "rust-feature-open-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "opened"
+    tasks: [lint, test]
+    priority: 100
+
+  - id: "rust-feature-sync-pr"
+    src_branch: "feature"
+    dst_branch: null
+    event: "synchronize"
+    tasks: [lint, test]
+    priority: 99
+
+  # ---- develop + push → lint + test + build ----
+
+  - id: "rust-develop-push"
+    src_branch: "develop"
+    dst_branch: "develop"
+    event: "push"
+    tasks: [lint, test, build]
+    priority: 90
+
+  - id: "rust-develop-merged"
+    src_branch: null
+    dst_branch: "develop"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 89
+
+  # ---- release/* merged PR to main/master → lint + test + build ----
+
+  - id: "rust-release-master-merged-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "closed"
+    merged: true
+    tasks: [lint, test, build]
+    priority: 80
+
+  - id: "rust-release-master-open-pr"
+    src_branch: "release"
+    dst_branch: "master"
+    event: "opened"
+    tasks: [lint, test]
+    priority: 79
+
+  # ---- main/master + push → lint + test + build + deploy ----
+
+  - id: "rust-master-push"
+    src_branch: "master"
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 70
+
+  - id: "rust-main-push"
+    src_branch: null
+    dst_branch: "master"
+    event: "push"
+    tasks: [lint, test, build, deploy]
+    priority: 69

--- a/resources/matrix/rust-standard.yml
+++ b/resources/matrix/rust-standard.yml
@@ -1,6 +1,6 @@
 # ci-orchestrator Rust standard branching matrix
-# Rules are evaluated top-to-bottom; first match wins.
-# Priority: higher number = evaluated first
+# Matching rules are selected by priority; higher numbers take precedence.
+# File order does not control evaluation.
 
 branch_patterns:
   feature: "^feature/"

--- a/resources/matrix/rust-standard.yml
+++ b/resources/matrix/rust-standard.yml
@@ -67,10 +67,3 @@ rules:
     event: "push"
     tasks: [lint, test, build, deploy]
     priority: 70
-
-  - id: "rust-main-push"
-    src_branch: null
-    dst_branch: "master"
-    event: "push"
-    tasks: [lint, test, build, deploy]
-    priority: 69

--- a/src/io/ciorch/build/adapters/CSharpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/CSharpAdapter.groovy
@@ -53,11 +53,11 @@ class CSharpAdapter implements BuildAdapter {
 
     @Override
     boolean test(Map buildConfig) {
-        String testCmd = buildConfig.test_command ?: "dotnet test"
+        String testCmd = buildConfig.test_command ?: config?.testCommand ?: "dotnet test"
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
@@ -66,11 +66,11 @@ class CSharpAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
-        String buildCmd = buildConfig.build_command ?: "dotnet publish -c Release -o publish/"
+        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "dotnet publish -c Release -o publish/"
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 

--- a/src/io/ciorch/build/adapters/CSharpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/CSharpAdapter.groovy
@@ -44,9 +44,16 @@ class CSharpAdapter implements BuildAdapter {
 
     @Override
     boolean lint(Map buildConfig) {
-        def result = system.run_command("dotnet format --verify-no-changes", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        String lintCmd = buildConfig.lint_command ?: config?.lintCommand ?: "dotnet format --verify-no-changes"
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${lintCmd}"]) {
+            result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
         if (result != 0) {
-            context?.echo("CSharpAdapter: dotnet format --verify-no-changes failed")
+            context?.echo("CSharpAdapter: lint failed")
             return false
         }
         return true

--- a/src/io/ciorch/build/adapters/CSharpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/CSharpAdapter.groovy
@@ -28,8 +28,9 @@ class CSharpAdapter implements BuildAdapter {
             return false
         }
 
-        if (buildConfig.dotnet_version) {
-            context?.echo("CSharpAdapter: requested dotnet_version=${buildConfig.dotnet_version} (informational only)")
+        String dotnetVersion = buildConfig.dotnet_version ?: config?.toolVersions?.dotnet_version
+        if (dotnetVersion) {
+            context?.echo("CSharpAdapter: requested dotnet_version=${dotnetVersion} (informational only)")
         }
 
         def restoreResult = system.run_command("dotnet restore", SystemCall.SHOW_COMMAND_STATUS_VALUE)

--- a/src/io/ciorch/build/adapters/CSharpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/CSharpAdapter.groovy
@@ -1,0 +1,93 @@
+package io.ciorch.build.adapters
+
+import java.io.Serializable
+import io.ciorch.build.BuildAdapter
+import io.ciorch.core.SystemCall
+import io.ciorch.core.Config
+
+class CSharpAdapter implements BuildAdapter {
+    def context = null
+    SystemCall system = null
+    Config config = null
+
+    private List<String> artifacts = []
+
+    CSharpAdapter(def context, SystemCall system, Config cfg = null) {
+        this.context = context
+        this.system = system
+        this.config = cfg
+    }
+
+    @Override
+    boolean prepare(Map buildConfig, def ctx) {
+        this.context = ctx ?: this.context
+
+        def result = system.run_command("dotnet --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (result != 0) {
+            context?.echo("CSharpAdapter: dotnet not found in PATH")
+            return false
+        }
+
+        if (buildConfig.dotnet_version) {
+            context?.echo("CSharpAdapter: requested dotnet_version=${buildConfig.dotnet_version} (informational only)")
+        }
+
+        def restoreResult = system.run_command("dotnet restore", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (restoreResult != 0) {
+            context?.echo("CSharpAdapter: dotnet restore failed")
+            return false
+        }
+
+        return true
+    }
+
+    @Override
+    boolean lint(Map buildConfig) {
+        def result = system.run_command("dotnet format --verify-no-changes", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (result != 0) {
+            context?.echo("CSharpAdapter: dotnet format --verify-no-changes failed")
+            return false
+        }
+        return true
+    }
+
+    @Override
+    boolean test(Map buildConfig) {
+        String testCmd = buildConfig.test_command ?: "dotnet test"
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        return result == 0
+    }
+
+    @Override
+    boolean build(Map buildConfig) {
+        String buildCmd = buildConfig.build_command ?: "dotnet publish -c Release -o publish/"
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        if (result == 0) {
+            artifacts = ["publish/"]
+            return true
+        }
+        return false
+    }
+
+    @Override
+    List<String> getArtifacts() {
+        return artifacts
+    }
+
+    @Override
+    String getName() {
+        return "csharp"
+    }
+}

--- a/src/io/ciorch/build/adapters/CSharpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/CSharpAdapter.groovy
@@ -66,15 +66,60 @@ class CSharpAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
-        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "dotnet publish -c Release -o publish/"
+        String defaultBuildCmd = "dotnet publish -c Release -o publish/"
+        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: defaultBuildCmd
 
         def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
-            artifacts = ["publish/"]
+            artifacts = resolveArtifacts(buildConfig, buildCmd, defaultBuildCmd)
             return true
         }
         return false
+    }
+
+    private List<String> resolveArtifacts(Map buildConfig, String buildCmd, String defaultBuildCmd) {
+        Map rawBuild = (config?.raw?.ciorch?.build ?: [:]) as Map
+        List<String> configuredArtifacts = normalizeArtifacts(buildConfig?.artifacts ?: rawBuild.artifacts)
+        if (configuredArtifacts) {
+            return configuredArtifacts
+        }
+
+        String outputPath = extractOutputPath(buildCmd)
+        if (outputPath) {
+            return [outputPath]
+        }
+
+        if (buildCmd == defaultBuildCmd) {
+            return ["publish/"]
+        }
+
+        return []
+    }
+
+    private List<String> normalizeArtifacts(def configuredArtifacts) {
+        if (!configuredArtifacts) {
+            return []
+        }
+
+        if (configuredArtifacts instanceof Collection) {
+            return configuredArtifacts.collect { it?.toString() }.findAll { it }
+        }
+
+        return [configuredArtifacts.toString()]
+    }
+
+    private String extractOutputPath(String buildCmd) {
+        if (!buildCmd) {
+            return null
+        }
+
+        def matcher = buildCmd =~ /(?:^|\s)(?:-o\s+|--output(?:\s+|=))(["']?)([^"'\s]+)\1/
+        if (matcher.find()) {
+            return matcher.group(2)
+        }
+
+        return null
     }
 
     @Override

--- a/src/io/ciorch/build/adapters/CSharpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/CSharpAdapter.groovy
@@ -68,6 +68,7 @@ class CSharpAdapter implements BuildAdapter {
     boolean build(Map buildConfig) {
         String defaultBuildCmd = "dotnet publish -c Release -o publish/"
         String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: defaultBuildCmd
+        artifacts = []
 
         def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 

--- a/src/io/ciorch/build/adapters/CSharpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/CSharpAdapter.groovy
@@ -46,11 +46,7 @@ class CSharpAdapter implements BuildAdapter {
     boolean lint(Map buildConfig) {
         String lintCmd = buildConfig.lint_command ?: config?.lintCommand ?: "dotnet format --verify-no-changes"
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${lintCmd}"]) {
-            result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result != 0) {
             context?.echo("CSharpAdapter: lint failed")
@@ -63,11 +59,7 @@ class CSharpAdapter implements BuildAdapter {
     boolean test(Map buildConfig) {
         String testCmd = buildConfig.test_command ?: config?.testCommand ?: "dotnet test"
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         return result == 0
     }
@@ -76,11 +68,7 @@ class CSharpAdapter implements BuildAdapter {
     boolean build(Map buildConfig) {
         String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "dotnet publish -c Release -o publish/"
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
             artifacts = ["publish/"]

--- a/src/io/ciorch/build/adapters/CppAdapter.groovy
+++ b/src/io/ciorch/build/adapters/CppAdapter.groovy
@@ -71,7 +71,7 @@ class CppAdapter implements BuildAdapter {
             return true
         }
 
-        def result = system.run_command("cppcheck --enable=warning .", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command("cppcheck --enable=warning --error-exitcode=1 .", SystemCall.SHOW_COMMAND_STATUS_VALUE)
         if (result != 0) {
             context?.echo("CppAdapter: cppcheck failed")
             return false

--- a/src/io/ciorch/build/adapters/CppAdapter.groovy
+++ b/src/io/ciorch/build/adapters/CppAdapter.groovy
@@ -10,6 +10,7 @@ class CppAdapter implements BuildAdapter {
     SystemCall system = null
     Config config = null
 
+    private String buildBackend = "make"
     private List<String> artifacts = []
 
     CppAdapter(def context, SystemCall system, Config cfg = null) {
@@ -31,6 +32,7 @@ class CppAdapter implements BuildAdapter {
         // Detect build backend: prefer ninja if present, fall back to make
         def ninjaResult = system.run_command("ninja --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
         if (ninjaResult == 0) {
+            this.buildBackend = "ninja"
             context?.echo("CppAdapter: using ninja as build backend")
         } else {
             def makeResult = system.run_command("make --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
@@ -38,6 +40,7 @@ class CppAdapter implements BuildAdapter {
                 context?.echo("CppAdapter: neither ninja nor make found in PATH")
                 return false
             }
+            this.buildBackend = "make"
             context?.echo("CppAdapter: using make as build backend")
         }
 
@@ -46,12 +49,12 @@ class CppAdapter implements BuildAdapter {
 
     @Override
     boolean lint(Map buildConfig) {
-        String lintCmd = buildConfig.lint_command ?: null
+        String lintCmd = buildConfig.lint_command ?: config?.lintCommand ?: null
 
         if (lintCmd) {
             def result = null
             context?.withEnv(["CIORCH_CMD=${lintCmd}"]) {
-                result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+                result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
             }
             if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
             if (result != 0) {
@@ -78,11 +81,11 @@ class CppAdapter implements BuildAdapter {
 
     @Override
     boolean test(Map buildConfig) {
-        String testCmd = buildConfig.test_command ?: "ctest --test-dir build"
+        String testCmd = buildConfig.test_command ?: config?.testCommand ?: "ctest --test-dir build"
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
@@ -91,9 +94,10 @@ class CppAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
-        // Configure step always runs
+        // Configure step: pass -G Ninja when ninja was detected in prepare()
+        String generatorFlag = (buildBackend == "ninja") ? " -G Ninja" : ""
         def configureResult = system.run_command(
-            "cmake -B build -DCMAKE_BUILD_TYPE=Release",
+            "cmake -B build -DCMAKE_BUILD_TYPE=Release${generatorFlag}",
             SystemCall.SHOW_COMMAND_STATUS_VALUE
         )
         if (configureResult != 0) {
@@ -101,11 +105,11 @@ class CppAdapter implements BuildAdapter {
             return false
         }
 
-        String buildCmd = buildConfig.build_command ?: "cmake --build build -j 4"
+        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "cmake --build build -j 4"
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 

--- a/src/io/ciorch/build/adapters/CppAdapter.groovy
+++ b/src/io/ciorch/build/adapters/CppAdapter.groovy
@@ -105,7 +105,7 @@ class CppAdapter implements BuildAdapter {
             return false
         }
 
-        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "cmake --build build -j 4"
+        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "cmake --build build --parallel 4"
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {

--- a/src/io/ciorch/build/adapters/CppAdapter.groovy
+++ b/src/io/ciorch/build/adapters/CppAdapter.groovy
@@ -1,0 +1,128 @@
+package io.ciorch.build.adapters
+
+import java.io.Serializable
+import io.ciorch.build.BuildAdapter
+import io.ciorch.core.SystemCall
+import io.ciorch.core.Config
+
+class CppAdapter implements BuildAdapter {
+    def context = null
+    SystemCall system = null
+    Config config = null
+
+    private List<String> artifacts = []
+
+    CppAdapter(def context, SystemCall system, Config cfg = null) {
+        this.context = context
+        this.system = system
+        this.config = cfg
+    }
+
+    @Override
+    boolean prepare(Map buildConfig, def ctx) {
+        this.context = ctx ?: this.context
+
+        def cmakeResult = system.run_command("cmake --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (cmakeResult != 0) {
+            context?.echo("CppAdapter: cmake not found in PATH")
+            return false
+        }
+
+        // Detect build backend: prefer ninja if present, fall back to make
+        def ninjaResult = system.run_command("ninja --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (ninjaResult == 0) {
+            context?.echo("CppAdapter: using ninja as build backend")
+        } else {
+            def makeResult = system.run_command("make --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (makeResult != 0) {
+                context?.echo("CppAdapter: neither ninja nor make found in PATH")
+                return false
+            }
+            context?.echo("CppAdapter: using make as build backend")
+        }
+
+        return true
+    }
+
+    @Override
+    boolean lint(Map buildConfig) {
+        String lintCmd = buildConfig.lint_command ?: null
+
+        if (lintCmd) {
+            def result = null
+            context?.withEnv(["CIORCH_CMD=${lintCmd}"]) {
+                result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            }
+            if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (result != 0) {
+                context?.echo("CppAdapter: lint failed")
+                return false
+            }
+            return true
+        }
+
+        // Check if cppcheck is available
+        def whichResult = system.run_command("which cppcheck", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (whichResult != 0) {
+            context?.echo("CppAdapter: cppcheck not found, skipping lint (non-fatal)")
+            return true
+        }
+
+        def result = system.run_command("cppcheck --enable=warning .", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (result != 0) {
+            context?.echo("CppAdapter: cppcheck failed")
+            return false
+        }
+        return true
+    }
+
+    @Override
+    boolean test(Map buildConfig) {
+        String testCmd = buildConfig.test_command ?: "ctest --test-dir build"
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        return result == 0
+    }
+
+    @Override
+    boolean build(Map buildConfig) {
+        // Configure step always runs
+        def configureResult = system.run_command(
+            "cmake -B build -DCMAKE_BUILD_TYPE=Release",
+            SystemCall.SHOW_COMMAND_STATUS_VALUE
+        )
+        if (configureResult != 0) {
+            context?.echo("CppAdapter: cmake configure failed")
+            return false
+        }
+
+        String buildCmd = buildConfig.build_command ?: "cmake --build build -j 4"
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        if (result == 0) {
+            artifacts = ["build/"]
+            return true
+        }
+        return false
+    }
+
+    @Override
+    List<String> getArtifacts() {
+        return artifacts
+    }
+
+    @Override
+    String getName() {
+        return "cpp"
+    }
+}

--- a/src/io/ciorch/build/adapters/CppAdapter.groovy
+++ b/src/io/ciorch/build/adapters/CppAdapter.groovy
@@ -52,11 +52,7 @@ class CppAdapter implements BuildAdapter {
         String lintCmd = buildConfig.lint_command ?: config?.lintCommand ?: null
 
         if (lintCmd) {
-            def result = null
-            context?.withEnv(["CIORCH_CMD=${lintCmd}"]) {
-                result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-            }
-            if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            def result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
             if (result != 0) {
                 context?.echo("CppAdapter: lint failed")
                 return false
@@ -83,11 +79,7 @@ class CppAdapter implements BuildAdapter {
     boolean test(Map buildConfig) {
         String testCmd = buildConfig.test_command ?: config?.testCommand ?: "ctest --test-dir build"
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         return result == 0
     }
@@ -107,11 +99,7 @@ class CppAdapter implements BuildAdapter {
 
         String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "cmake --build build --parallel 4"
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
             artifacts = ["build/"]

--- a/src/io/ciorch/build/adapters/CppAdapter.groovy
+++ b/src/io/ciorch/build/adapters/CppAdapter.groovy
@@ -86,6 +86,8 @@ class CppAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
+        artifacts = []
+
         // Configure step: pass -G Ninja when ninja was detected in prepare()
         String generatorFlag = (buildBackend == "ninja") ? " -G Ninja" : ""
         def configureResult = system.run_command(

--- a/src/io/ciorch/build/adapters/CppAdapter.groovy
+++ b/src/io/ciorch/build/adapters/CppAdapter.groovy
@@ -86,28 +86,52 @@ class CppAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
+        String defaultBuildCmd = "cmake --build build --parallel 4"
+        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: defaultBuildCmd
         artifacts = []
 
-        // Configure step: pass -G Ninja when ninja was detected in prepare()
-        String generatorFlag = (buildBackend == "ninja") ? " -G Ninja" : ""
-        def configureResult = system.run_command(
-            "cmake -B build -DCMAKE_BUILD_TYPE=Release${generatorFlag}",
-            SystemCall.SHOW_COMMAND_STATUS_VALUE
-        )
-        if (configureResult != 0) {
-            context?.echo("CppAdapter: cmake configure failed")
-            return false
+        if (buildCmd == defaultBuildCmd) {
+            // Configure step: pass -G Ninja when ninja was detected in prepare()
+            String generatorFlag = (buildBackend == "ninja") ? " -G Ninja" : ""
+            def configureResult = system.run_command(
+                "cmake -B build -DCMAKE_BUILD_TYPE=Release${generatorFlag}",
+                SystemCall.SHOW_COMMAND_STATUS_VALUE
+            )
+            if (configureResult != 0) {
+                context?.echo("CppAdapter: cmake configure failed")
+                return false
+            }
         }
-
-        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "cmake --build build --parallel 4"
 
         def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
-            artifacts = ["build/"]
+            artifacts = resolveArtifacts(buildConfig, buildCmd, defaultBuildCmd)
             return true
         }
         return false
+    }
+
+    private List<String> resolveArtifacts(Map buildConfig, String buildCmd, String defaultBuildCmd) {
+        Map rawBuild = (config?.raw?.ciorch?.build ?: [:]) as Map
+        List<String> configuredArtifacts = normalizeArtifacts(buildConfig?.artifacts ?: rawBuild.artifacts)
+        if (configuredArtifacts) {
+            return configuredArtifacts
+        }
+
+        return (buildCmd == defaultBuildCmd) ? ["build/"] : []
+    }
+
+    private List<String> normalizeArtifacts(def configuredArtifacts) {
+        if (!configuredArtifacts) {
+            return []
+        }
+
+        if (configuredArtifacts instanceof Collection) {
+            return configuredArtifacts.collect { it?.toString() }.findAll { it }
+        }
+
+        return [configuredArtifacts.toString()]
     }
 
     @Override

--- a/src/io/ciorch/build/adapters/GenericAdapter.groovy
+++ b/src/io/ciorch/build/adapters/GenericAdapter.groovy
@@ -102,7 +102,13 @@ class GenericAdapter implements BuildAdapter {
 
         if (result == 0) {
             def configArtifacts = buildConfig.artifacts ?: rawBuild.artifacts
-            artifacts = configArtifacts ? (List<String>) configArtifacts : []
+            if (!configArtifacts) {
+                artifacts = []
+            } else if (configArtifacts instanceof List) {
+                artifacts = (configArtifacts as List).collect { it as String }
+            } else {
+                artifacts = [configArtifacts as String]
+            }
             return true
         }
         return false

--- a/src/io/ciorch/build/adapters/GenericAdapter.groovy
+++ b/src/io/ciorch/build/adapters/GenericAdapter.groovy
@@ -22,7 +22,10 @@ class GenericAdapter implements BuildAdapter {
     boolean prepare(Map buildConfig, def ctx) {
         this.context = ctx ?: this.context
 
-        String installCmd = buildConfig.install_command ?: buildConfig.prepare_command ?: null
+        // Fall back to raw build config from ciorch.yml when orchestrator passes [:]
+        Map rawBuild = (config?.raw?.ciorch?.build ?: [:]) as Map
+        String installCmd = buildConfig.install_command ?: buildConfig.prepare_command ?:
+            rawBuild.install_command ?: rawBuild.prepare_command ?: null
 
         if (!installCmd) {
             context?.echo("GenericAdapter: no install command configured, skipping prepare")
@@ -31,7 +34,7 @@ class GenericAdapter implements BuildAdapter {
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${installCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(installCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(installCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
@@ -40,7 +43,8 @@ class GenericAdapter implements BuildAdapter {
 
     @Override
     boolean lint(Map buildConfig) {
-        String lintCmd = buildConfig.lint_command ?: null
+        Map rawBuild = (config?.raw?.ciorch?.build ?: [:]) as Map
+        String lintCmd = buildConfig.lint_command ?: config?.lintCommand ?: rawBuild.lint_command ?: null
 
         if (!lintCmd) {
             context?.echo("GenericAdapter: no lint_command configured, skipping lint (non-fatal)")
@@ -49,7 +53,7 @@ class GenericAdapter implements BuildAdapter {
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${lintCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
@@ -62,7 +66,8 @@ class GenericAdapter implements BuildAdapter {
 
     @Override
     boolean test(Map buildConfig) {
-        String testCmd = buildConfig.test_command ?: null
+        Map rawBuild = (config?.raw?.ciorch?.build ?: [:]) as Map
+        String testCmd = buildConfig.test_command ?: config?.testCommand ?: rawBuild.test_command ?: null
 
         if (!testCmd) {
             context?.echo("GenericAdapter: no test_command configured, skipping test (non-fatal)")
@@ -71,7 +76,7 @@ class GenericAdapter implements BuildAdapter {
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
@@ -80,7 +85,8 @@ class GenericAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
-        String buildCmd = buildConfig.build_command ?: null
+        Map rawBuild = (config?.raw?.ciorch?.build ?: [:]) as Map
+        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: rawBuild.build_command ?: null
 
         if (!buildCmd) {
             context?.echo("GenericAdapter: no build_command configured, skipping build (non-fatal)")
@@ -90,12 +96,12 @@ class GenericAdapter implements BuildAdapter {
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
-            def configArtifacts = buildConfig.artifacts
+            def configArtifacts = buildConfig.artifacts ?: rawBuild.artifacts
             artifacts = configArtifacts ? (List<String>) configArtifacts : []
             return true
         }

--- a/src/io/ciorch/build/adapters/GenericAdapter.groovy
+++ b/src/io/ciorch/build/adapters/GenericAdapter.groovy
@@ -1,0 +1,114 @@
+package io.ciorch.build.adapters
+
+import java.io.Serializable
+import io.ciorch.build.BuildAdapter
+import io.ciorch.core.SystemCall
+import io.ciorch.core.Config
+
+class GenericAdapter implements BuildAdapter {
+    def context = null
+    SystemCall system = null
+    Config config = null
+
+    private List<String> artifacts = []
+
+    GenericAdapter(def context, SystemCall system, Config cfg = null) {
+        this.context = context
+        this.system = system
+        this.config = cfg
+    }
+
+    @Override
+    boolean prepare(Map buildConfig, def ctx) {
+        this.context = ctx ?: this.context
+
+        String installCmd = buildConfig.install_command ?: buildConfig.prepare_command ?: null
+
+        if (!installCmd) {
+            context?.echo("GenericAdapter: no install command configured, skipping prepare")
+            return true
+        }
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${installCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(installCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        return result == 0
+    }
+
+    @Override
+    boolean lint(Map buildConfig) {
+        String lintCmd = buildConfig.lint_command ?: null
+
+        if (!lintCmd) {
+            context?.echo("GenericAdapter: no lint_command configured, skipping lint (non-fatal)")
+            return true
+        }
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${lintCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        if (result != 0) {
+            context?.echo("GenericAdapter: lint failed")
+            return false
+        }
+        return true
+    }
+
+    @Override
+    boolean test(Map buildConfig) {
+        String testCmd = buildConfig.test_command ?: null
+
+        if (!testCmd) {
+            context?.echo("GenericAdapter: no test_command configured, skipping test (non-fatal)")
+            return true
+        }
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        return result == 0
+    }
+
+    @Override
+    boolean build(Map buildConfig) {
+        String buildCmd = buildConfig.build_command ?: null
+
+        if (!buildCmd) {
+            context?.echo("GenericAdapter: no build_command configured, skipping build (non-fatal)")
+            artifacts = []
+            return true
+        }
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        if (result == 0) {
+            def configArtifacts = buildConfig.artifacts
+            artifacts = configArtifacts ? (List<String>) configArtifacts : []
+            return true
+        }
+        return false
+    }
+
+    @Override
+    List<String> getArtifacts() {
+        return artifacts
+    }
+
+    @Override
+    String getName() {
+        return "generic"
+    }
+}

--- a/src/io/ciorch/build/adapters/GenericAdapter.groovy
+++ b/src/io/ciorch/build/adapters/GenericAdapter.groovy
@@ -32,11 +32,7 @@ class GenericAdapter implements BuildAdapter {
             return true
         }
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${installCmd}"]) {
-            result = system.run_command(installCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(installCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(installCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         return result == 0
     }
@@ -51,11 +47,7 @@ class GenericAdapter implements BuildAdapter {
             return true
         }
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${lintCmd}"]) {
-            result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result != 0) {
             context?.echo("GenericAdapter: lint failed")
@@ -74,11 +66,7 @@ class GenericAdapter implements BuildAdapter {
             return true
         }
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         return result == 0
     }
@@ -94,11 +82,7 @@ class GenericAdapter implements BuildAdapter {
             return true
         }
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
             def configArtifacts = buildConfig.artifacts ?: rawBuild.artifacts

--- a/src/io/ciorch/build/adapters/GenericAdapter.groovy
+++ b/src/io/ciorch/build/adapters/GenericAdapter.groovy
@@ -22,20 +22,30 @@ class GenericAdapter implements BuildAdapter {
     boolean prepare(Map buildConfig, def ctx) {
         this.context = ctx ?: this.context
 
-        // Fall back to raw build config from ciorch.yml because config.buildMap()
-        // intentionally omits raw keys such as install_command/prepare_command.
         Map rawBuild = (config?.raw?.ciorch?.build ?: [:]) as Map
-        String installCmd = buildConfig.install_command ?: buildConfig.prepare_command ?:
-            rawBuild.install_command ?: rawBuild.prepare_command ?: null
+        String installCmd = buildConfig.install_command ?: rawBuild.install_command ?: null
+        String prepareCmd = buildConfig.prepare_command ?: rawBuild.prepare_command ?: null
 
-        if (!installCmd) {
-            context?.echo("GenericAdapter: no install command configured, skipping prepare")
+        if (!installCmd && !prepareCmd) {
+            context?.echo("GenericAdapter: no install_command or prepare_command configured, skipping prepare")
             return true
         }
 
-        def result = system.run_command(installCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (installCmd) {
+            def installResult = system.run_command(installCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (installResult != 0) {
+                return false
+            }
+        }
 
-        return result == 0
+        if (prepareCmd) {
+            def prepareResult = system.run_command(prepareCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (prepareResult != 0) {
+                return false
+            }
+        }
+
+        return true
     }
 
     @Override

--- a/src/io/ciorch/build/adapters/GenericAdapter.groovy
+++ b/src/io/ciorch/build/adapters/GenericAdapter.groovy
@@ -76,10 +76,10 @@ class GenericAdapter implements BuildAdapter {
     boolean build(Map buildConfig) {
         Map rawBuild = (config?.raw?.ciorch?.build ?: [:]) as Map
         String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: rawBuild.build_command ?: null
+        artifacts = []
 
         if (!buildCmd) {
             context?.echo("GenericAdapter: no build_command configured, skipping build (non-fatal)")
-            artifacts = []
             return true
         }
 

--- a/src/io/ciorch/build/adapters/GenericAdapter.groovy
+++ b/src/io/ciorch/build/adapters/GenericAdapter.groovy
@@ -22,7 +22,8 @@ class GenericAdapter implements BuildAdapter {
     boolean prepare(Map buildConfig, def ctx) {
         this.context = ctx ?: this.context
 
-        // Fall back to raw build config from ciorch.yml when orchestrator passes [:]
+        // Fall back to raw build config from ciorch.yml because config.buildMap()
+        // intentionally omits raw keys such as install_command/prepare_command.
         Map rawBuild = (config?.raw?.ciorch?.build ?: [:]) as Map
         String installCmd = buildConfig.install_command ?: buildConfig.prepare_command ?:
             rawBuild.install_command ?: rawBuild.prepare_command ?: null

--- a/src/io/ciorch/build/adapters/GoAdapter.groovy
+++ b/src/io/ciorch/build/adapters/GoAdapter.groovy
@@ -1,0 +1,99 @@
+package io.ciorch.build.adapters
+
+import java.io.Serializable
+import io.ciorch.build.BuildAdapter
+import io.ciorch.core.SystemCall
+import io.ciorch.core.Config
+
+class GoAdapter implements BuildAdapter {
+    def context = null
+    SystemCall system = null
+    Config config = null
+
+    private List<String> artifacts = []
+
+    GoAdapter(def context, SystemCall system, Config cfg = null) {
+        this.context = context
+        this.system = system
+        this.config = cfg
+    }
+
+    @Override
+    boolean prepare(Map buildConfig, def ctx) {
+        this.context = ctx ?: this.context
+
+        def result = system.run_command("go version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (result != 0) {
+            context?.echo("GoAdapter: go not found in PATH")
+            return false
+        }
+
+        if (buildConfig.go_version) {
+            context?.echo("GoAdapter: requested go_version=${buildConfig.go_version} (informational only)")
+        }
+
+        return true
+    }
+
+    @Override
+    boolean lint(Map buildConfig) {
+        def vetResult = system.run_command("go vet ./...", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (vetResult != 0) {
+            context?.echo("GoAdapter: go vet failed")
+            return false
+        }
+
+        def lintCheck = system.run_command("which golangci-lint", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (lintCheck == 0) {
+            def lintResult = system.run_command("golangci-lint run ./...", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (lintResult != 0) {
+                context?.echo("GoAdapter: golangci-lint failed")
+                return false
+            }
+        } else {
+            context?.echo("GoAdapter: golangci-lint not found, skipping (non-fatal)")
+        }
+
+        return true
+    }
+
+    @Override
+    boolean test(Map buildConfig) {
+        String testCmd = buildConfig.test_command ?: "go test ./..."
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        return result == 0
+    }
+
+    @Override
+    boolean build(Map buildConfig) {
+        String buildCmd = buildConfig.build_command ?: "go build ./..."
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        if (result == 0) {
+            artifacts = ["./..."]
+            return true
+        }
+        return false
+    }
+
+    @Override
+    List<String> getArtifacts() {
+        return artifacts
+    }
+
+    @Override
+    String getName() {
+        return "go"
+    }
+}

--- a/src/io/ciorch/build/adapters/GoAdapter.groovy
+++ b/src/io/ciorch/build/adapters/GoAdapter.groovy
@@ -59,11 +59,11 @@ class GoAdapter implements BuildAdapter {
 
     @Override
     boolean test(Map buildConfig) {
-        String testCmd = buildConfig.test_command ?: "go test ./..."
+        String testCmd = buildConfig.test_command ?: config?.testCommand ?: "go test ./..."
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
@@ -72,11 +72,11 @@ class GoAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
-        String buildCmd = buildConfig.build_command ?: "go build ./..."
+        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "go build ./..."
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 

--- a/src/io/ciorch/build/adapters/GoAdapter.groovy
+++ b/src/io/ciorch/build/adapters/GoAdapter.groovy
@@ -28,8 +28,9 @@ class GoAdapter implements BuildAdapter {
             return false
         }
 
-        if (buildConfig.go_version) {
-            context?.echo("GoAdapter: requested go_version=${buildConfig.go_version} (informational only)")
+        String goVersion = buildConfig.go_version ?: config?.toolVersions?.go_version
+        if (goVersion) {
+            context?.echo("GoAdapter: requested go_version=${goVersion} (informational only)")
         }
 
         return true

--- a/src/io/ciorch/build/adapters/GoAdapter.groovy
+++ b/src/io/ciorch/build/adapters/GoAdapter.groovy
@@ -38,6 +38,20 @@ class GoAdapter implements BuildAdapter {
 
     @Override
     boolean lint(Map buildConfig) {
+        String overrideCmd = buildConfig.lint_command ?: config?.lintCommand
+        if (overrideCmd) {
+            def result = null
+            context?.withEnv(["CIORCH_CMD=${overrideCmd}"]) {
+                result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            }
+            if (result == null) result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (result != 0) {
+                context?.echo("GoAdapter: lint failed")
+                return false
+            }
+            return true
+        }
+
         def vetResult = system.run_command("go vet ./...", SystemCall.SHOW_COMMAND_STATUS_VALUE)
         if (vetResult != 0) {
             context?.echo("GoAdapter: go vet failed")
@@ -82,7 +96,7 @@ class GoAdapter implements BuildAdapter {
         if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
-            artifacts = ["./..."]
+            artifacts = []
             return true
         }
         return false

--- a/src/io/ciorch/build/adapters/GoAdapter.groovy
+++ b/src/io/ciorch/build/adapters/GoAdapter.groovy
@@ -65,7 +65,7 @@ class GoAdapter implements BuildAdapter {
         context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
             result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
-        if (result == null) result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         return result == 0
     }
@@ -78,7 +78,7 @@ class GoAdapter implements BuildAdapter {
         context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
             result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
-        if (result == null) result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
             artifacts = ["./..."]

--- a/src/io/ciorch/build/adapters/GoAdapter.groovy
+++ b/src/io/ciorch/build/adapters/GoAdapter.groovy
@@ -80,11 +80,11 @@ class GoAdapter implements BuildAdapter {
     @Override
     boolean build(Map buildConfig) {
         String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "go build ./..."
+        artifacts = []
 
         def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
-            artifacts = []
             return true
         }
         return false

--- a/src/io/ciorch/build/adapters/GoAdapter.groovy
+++ b/src/io/ciorch/build/adapters/GoAdapter.groovy
@@ -40,11 +40,7 @@ class GoAdapter implements BuildAdapter {
     boolean lint(Map buildConfig) {
         String overrideCmd = buildConfig.lint_command ?: config?.lintCommand
         if (overrideCmd) {
-            def result = null
-            context?.withEnv(["CIORCH_CMD=${overrideCmd}"]) {
-                result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-            }
-            if (result == null) result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            def result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
             if (result != 0) {
                 context?.echo("GoAdapter: lint failed")
                 return false
@@ -76,11 +72,7 @@ class GoAdapter implements BuildAdapter {
     boolean test(Map buildConfig) {
         String testCmd = buildConfig.test_command ?: config?.testCommand ?: "go test ./..."
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         return result == 0
     }
@@ -89,11 +81,7 @@ class GoAdapter implements BuildAdapter {
     boolean build(Map buildConfig) {
         String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "go build ./..."
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
             artifacts = []

--- a/src/io/ciorch/build/adapters/JavaAdapter.groovy
+++ b/src/io/ciorch/build/adapters/JavaAdapter.groovy
@@ -1,0 +1,147 @@
+package io.ciorch.build.adapters
+
+import java.io.Serializable
+import io.ciorch.build.BuildAdapter
+import io.ciorch.core.SystemCall
+import io.ciorch.core.Config
+
+class JavaAdapter implements BuildAdapter {
+    def context = null
+    SystemCall system = null
+    Config config = null
+
+    String buildTool = "maven"
+    private List<String> artifacts = []
+
+    JavaAdapter(def context, SystemCall system, Config cfg = null) {
+        this.context = context
+        this.system = system
+        this.config = cfg
+    }
+
+    @Override
+    boolean prepare(Map buildConfig, def ctx) {
+        this.context = ctx ?: this.context
+
+        def result = system.run_command("java -version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (result != 0) {
+            context?.echo("JavaAdapter: java not found in PATH")
+            return false
+        }
+
+        if (buildConfig.java_version) {
+            context?.echo("JavaAdapter: requested java_version=${buildConfig.java_version}")
+        }
+
+        // Determine build tool: config key takes precedence, then file detection
+        if (buildConfig.build_tool) {
+            this.buildTool = buildConfig.build_tool
+        } else {
+            this.buildTool = _detectBuildTool()
+        }
+
+        context?.echo("JavaAdapter: using build tool=${this.buildTool}")
+
+        if (this.buildTool == "gradle") {
+            def gradleResult = system.run_command("gradle --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (gradleResult != 0) {
+                context?.echo("JavaAdapter: gradle not found in PATH")
+                return false
+            }
+        } else {
+            def mvnResult = system.run_command("mvn --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (mvnResult != 0) {
+                context?.echo("JavaAdapter: mvn not found in PATH")
+                return false
+            }
+        }
+
+        return true
+    }
+
+    @Override
+    boolean lint(Map buildConfig) {
+        String lintCmd
+        if (buildConfig.lint_command) {
+            lintCmd = buildConfig.lint_command
+        } else if (buildTool == "gradle") {
+            lintCmd = "./gradlew check -q"
+        } else {
+            lintCmd = "mvn checkstyle:check -q"
+        }
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${lintCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        if (result != 0) {
+            context?.echo("JavaAdapter: lint failed")
+            return false
+        }
+        return true
+    }
+
+    @Override
+    boolean test(Map buildConfig) {
+        String testCmd
+        if (buildConfig.test_command) {
+            testCmd = buildConfig.test_command
+        } else if (buildTool == "gradle") {
+            testCmd = "./gradlew test"
+        } else {
+            testCmd = "mvn test -q"
+        }
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        return result == 0
+    }
+
+    @Override
+    boolean build(Map buildConfig) {
+        String buildCmd
+        if (buildConfig.build_command) {
+            buildCmd = buildConfig.build_command
+        } else if (buildTool == "gradle") {
+            buildCmd = "./gradlew build -x test"
+        } else {
+            buildCmd = "mvn package -DskipTests -q"
+        }
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        if (result == 0) {
+            artifacts = (buildTool == "gradle") ? ["build/libs/"] : ["target/"]
+            return true
+        }
+        return false
+    }
+
+    @Override
+    List<String> getArtifacts() {
+        return artifacts
+    }
+
+    @Override
+    String getName() {
+        return "java"
+    }
+
+    @groovy.transform.CompileStatic
+    private String _detectBuildTool() {
+        File gradleFile = new File("build.gradle")
+        File gradleKtsFile = new File("build.gradle.kts")
+        if (gradleFile.exists() || gradleKtsFile.exists()) return "gradle"
+        return "maven"
+    }
+}

--- a/src/io/ciorch/build/adapters/JavaAdapter.groovy
+++ b/src/io/ciorch/build/adapters/JavaAdapter.groovy
@@ -29,13 +29,15 @@ class JavaAdapter implements BuildAdapter {
             return false
         }
 
-        if (buildConfig.java_version) {
-            context?.echo("JavaAdapter: requested java_version=${buildConfig.java_version}")
+        String javaVersion = buildConfig.java_version ?: config?.toolVersions?.java_version
+        if (javaVersion) {
+            context?.echo("JavaAdapter: requested java_version=${javaVersion}")
         }
 
-        // Determine build tool: config key takes precedence, then file detection
-        if (buildConfig.build_tool) {
-            String requested = buildConfig.build_tool as String
+        // Determine build tool: buildConfig key → ciorch.yml raw → file detection
+        String toolHint = buildConfig.build_tool ?: config?.raw?.ciorch?.build?.build_tool
+        if (toolHint) {
+            String requested = toolHint as String
             if (requested == "gradle" || requested == "maven") {
                 this.buildTool = requested
             } else {

--- a/src/io/ciorch/build/adapters/JavaAdapter.groovy
+++ b/src/io/ciorch/build/adapters/JavaAdapter.groovy
@@ -32,7 +32,7 @@ class JavaAdapter implements BuildAdapter {
 
         String javaVersion = buildConfig.java_version ?: config?.toolVersions?.java_version
         if (javaVersion) {
-            context?.echo("JavaAdapter: requested java_version=${javaVersion}")
+            context?.echo("JavaAdapter: requested java_version=${javaVersion} (informational only)")
         }
 
         // Determine build tool: buildConfig key → ciorch.yml raw → file detection

--- a/src/io/ciorch/build/adapters/JavaAdapter.groovy
+++ b/src/io/ciorch/build/adapters/JavaAdapter.groovy
@@ -55,9 +55,19 @@ class JavaAdapter implements BuildAdapter {
             // prefer Gradle wrapper (runs on agent workspace); fall back to system gradle
             def wrapperCheck = system.run_command("test -f gradlew", SystemCall.SHOW_COMMAND_STATUS_VALUE)
             if (wrapperCheck == 0) {
-                system.run_command("chmod +x gradlew", SystemCall.SHOW_COMMAND_STATUS_VALUE)
-                this.gradleCmd = "./gradlew"
-                context?.echo("JavaAdapter: using Gradle wrapper (./gradlew)")
+                def chmodResult = system.run_command("chmod +x gradlew", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+                if (chmodResult == 0) {
+                    this.gradleCmd = "./gradlew"
+                    context?.echo("JavaAdapter: using Gradle wrapper (./gradlew)")
+                } else {
+                    context?.echo("JavaAdapter: chmod +x gradlew failed, falling back to system gradle")
+                    def gradleFallback = system.run_command("gradle --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+                    if (gradleFallback != 0) {
+                        context?.echo("JavaAdapter: chmod +x gradlew failed and gradle not in PATH")
+                        return false
+                    }
+                    this.gradleCmd = "gradle"
+                }
             } else {
                 def gradleResult = system.run_command("gradle --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
                 if (gradleResult != 0) {

--- a/src/io/ciorch/build/adapters/JavaAdapter.groovy
+++ b/src/io/ciorch/build/adapters/JavaAdapter.groovy
@@ -35,7 +35,13 @@ class JavaAdapter implements BuildAdapter {
 
         // Determine build tool: config key takes precedence, then file detection
         if (buildConfig.build_tool) {
-            this.buildTool = buildConfig.build_tool
+            String requested = buildConfig.build_tool as String
+            if (requested == "gradle" || requested == "maven") {
+                this.buildTool = requested
+            } else {
+                context?.echo("JavaAdapter: unknown build_tool '${requested}', defaulting to maven")
+                this.buildTool = "maven"
+            }
         } else {
             this.buildTool = _detectBuildTool()
         }
@@ -64,6 +70,8 @@ class JavaAdapter implements BuildAdapter {
         String lintCmd
         if (buildConfig.lint_command) {
             lintCmd = buildConfig.lint_command
+        } else if (config?.lintCommand) {
+            lintCmd = config.lintCommand
         } else if (buildTool == "gradle") {
             lintCmd = "./gradlew check -q"
         } else {
@@ -72,7 +80,7 @@ class JavaAdapter implements BuildAdapter {
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${lintCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
@@ -88,6 +96,8 @@ class JavaAdapter implements BuildAdapter {
         String testCmd
         if (buildConfig.test_command) {
             testCmd = buildConfig.test_command
+        } else if (config?.testCommand) {
+            testCmd = config.testCommand
         } else if (buildTool == "gradle") {
             testCmd = "./gradlew test"
         } else {
@@ -96,7 +106,7 @@ class JavaAdapter implements BuildAdapter {
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
@@ -108,6 +118,8 @@ class JavaAdapter implements BuildAdapter {
         String buildCmd
         if (buildConfig.build_command) {
             buildCmd = buildConfig.build_command
+        } else if (config?.buildCommand) {
+            buildCmd = config.buildCommand
         } else if (buildTool == "gradle") {
             buildCmd = "./gradlew build -x test"
         } else {
@@ -116,7 +128,7 @@ class JavaAdapter implements BuildAdapter {
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 

--- a/src/io/ciorch/build/adapters/JavaAdapter.groovy
+++ b/src/io/ciorch/build/adapters/JavaAdapter.groovy
@@ -11,6 +11,7 @@ class JavaAdapter implements BuildAdapter {
     Config config = null
 
     String buildTool = "maven"
+    String gradleCmd = "./gradlew"
     private List<String> artifacts = []
 
     JavaAdapter(def context, SystemCall system, Config cfg = null) {
@@ -51,10 +52,20 @@ class JavaAdapter implements BuildAdapter {
         context?.echo("JavaAdapter: using build tool=${this.buildTool}")
 
         if (this.buildTool == "gradle") {
-            def gradleResult = system.run_command("gradle --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
-            if (gradleResult != 0) {
-                context?.echo("JavaAdapter: gradle not found in PATH")
-                return false
+            // prefer Gradle wrapper (runs on agent workspace); fall back to system gradle
+            def wrapperCheck = system.run_command("test -f gradlew", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (wrapperCheck == 0) {
+                system.run_command("chmod +x gradlew", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+                this.gradleCmd = "./gradlew"
+                context?.echo("JavaAdapter: using Gradle wrapper (./gradlew)")
+            } else {
+                def gradleResult = system.run_command("gradle --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+                if (gradleResult != 0) {
+                    context?.echo("JavaAdapter: neither ./gradlew nor gradle found in PATH")
+                    return false
+                }
+                this.gradleCmd = "gradle"
+                context?.echo("JavaAdapter: using system gradle")
             }
         } else {
             def mvnResult = system.run_command("mvn --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
@@ -75,7 +86,7 @@ class JavaAdapter implements BuildAdapter {
         } else if (config?.lintCommand) {
             lintCmd = config.lintCommand
         } else if (buildTool == "gradle") {
-            lintCmd = "./gradlew check -q"
+            lintCmd = "${gradleCmd} check -q"
         } else {
             lintCmd = "mvn checkstyle:check -q"
         }
@@ -101,7 +112,7 @@ class JavaAdapter implements BuildAdapter {
         } else if (config?.testCommand) {
             testCmd = config.testCommand
         } else if (buildTool == "gradle") {
-            testCmd = "./gradlew test"
+            testCmd = "${gradleCmd} test"
         } else {
             testCmd = "mvn test -q"
         }
@@ -123,7 +134,7 @@ class JavaAdapter implements BuildAdapter {
         } else if (config?.buildCommand) {
             buildCmd = config.buildCommand
         } else if (buildTool == "gradle") {
-            buildCmd = "./gradlew build -x test"
+            buildCmd = "${gradleCmd} build -x test"
         } else {
             buildCmd = "mvn package -DskipTests -q"
         }
@@ -151,11 +162,10 @@ class JavaAdapter implements BuildAdapter {
         return "java"
     }
 
-    @groovy.transform.CompileStatic
     private String _detectBuildTool() {
-        File gradleFile = new File("build.gradle")
-        File gradleKtsFile = new File("build.gradle.kts")
-        if (gradleFile.exists() || gradleKtsFile.exists()) return "gradle"
+        def hasGradle = system.run_command("test -f build.gradle", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def hasGradleKts = system.run_command("test -f build.gradle.kts", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (hasGradle == 0 || hasGradleKts == 0) return "gradle"
         return "maven"
     }
 }

--- a/src/io/ciorch/build/adapters/JavaAdapter.groovy
+++ b/src/io/ciorch/build/adapters/JavaAdapter.groovy
@@ -96,7 +96,7 @@ class JavaAdapter implements BuildAdapter {
         } else if (config?.lintCommand) {
             lintCmd = config.lintCommand
         } else if (buildTool == "gradle") {
-            lintCmd = "${gradleCmd} check -q"
+            lintCmd = "${gradleCmd} checkstyleMain checkstyleTest -q"
         } else {
             lintCmd = "mvn checkstyle:check -q"
         }

--- a/src/io/ciorch/build/adapters/JavaAdapter.groovy
+++ b/src/io/ciorch/build/adapters/JavaAdapter.groovy
@@ -140,6 +140,7 @@ class JavaAdapter implements BuildAdapter {
         } else {
             buildCmd = "mvn package -DskipTests -q"
         }
+        artifacts = []
 
         def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 

--- a/src/io/ciorch/build/adapters/JavaAdapter.groovy
+++ b/src/io/ciorch/build/adapters/JavaAdapter.groovy
@@ -130,25 +130,50 @@ class JavaAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
+        String defaultBuildCmd = (buildTool == "gradle") ? "${gradleCmd} build -x test" : "mvn package -DskipTests -q"
         String buildCmd
         if (buildConfig.build_command) {
             buildCmd = buildConfig.build_command
         } else if (config?.buildCommand) {
             buildCmd = config.buildCommand
-        } else if (buildTool == "gradle") {
-            buildCmd = "${gradleCmd} build -x test"
         } else {
-            buildCmd = "mvn package -DskipTests -q"
+            buildCmd = defaultBuildCmd
         }
         artifacts = []
 
         def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
-            artifacts = (buildTool == "gradle") ? ["build/libs/"] : ["target/"]
+            artifacts = resolveArtifacts(buildConfig, buildCmd, defaultBuildCmd)
             return true
         }
         return false
+    }
+
+    private List<String> resolveArtifacts(Map buildConfig, String buildCmd, String defaultBuildCmd) {
+        Map rawBuild = (config?.raw?.ciorch?.build ?: [:]) as Map
+        List<String> configuredArtifacts = normalizeArtifacts(buildConfig?.artifacts ?: rawBuild.artifacts)
+        if (configuredArtifacts) {
+            return configuredArtifacts
+        }
+
+        if (buildCmd == defaultBuildCmd) {
+            return (buildTool == "gradle") ? ["build/libs/"] : ["target/"]
+        }
+
+        return []
+    }
+
+    private List<String> normalizeArtifacts(def configuredArtifacts) {
+        if (!configuredArtifacts) {
+            return []
+        }
+
+        if (configuredArtifacts instanceof Collection) {
+            return configuredArtifacts.collect { it?.toString() }.findAll { it }
+        }
+
+        return [configuredArtifacts.toString()]
     }
 
     @Override

--- a/src/io/ciorch/build/adapters/JavaAdapter.groovy
+++ b/src/io/ciorch/build/adapters/JavaAdapter.groovy
@@ -101,11 +101,7 @@ class JavaAdapter implements BuildAdapter {
             lintCmd = "mvn checkstyle:check -q"
         }
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${lintCmd}"]) {
-            result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result != 0) {
             context?.echo("JavaAdapter: lint failed")
@@ -127,11 +123,7 @@ class JavaAdapter implements BuildAdapter {
             testCmd = "mvn test -q"
         }
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         return result == 0
     }
@@ -149,11 +141,7 @@ class JavaAdapter implements BuildAdapter {
             buildCmd = "mvn package -DskipTests -q"
         }
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
             artifacts = (buildTool == "gradle") ? ["build/libs/"] : ["target/"]

--- a/src/io/ciorch/build/adapters/NodeAdapter.groovy
+++ b/src/io/ciorch/build/adapters/NodeAdapter.groovy
@@ -10,6 +10,7 @@ class NodeAdapter implements BuildAdapter {
     SystemCall system = null
     Config config = null
 
+    String packageManager = "npm"
     private List<String> artifacts = []
 
     NodeAdapter(def context, SystemCall system, Config cfg = null) {
@@ -28,13 +29,25 @@ class NodeAdapter implements BuildAdapter {
             return false
         }
 
-        if (buildConfig.node_version) {
-            context?.echo("NodeAdapter: requested node_version=${buildConfig.node_version}")
+        String nodeVersion = buildConfig.node_version ?: config?.toolVersions?.node_version
+        if (nodeVersion) {
+            context?.echo("NodeAdapter: requested node_version=${nodeVersion}")
         }
 
-        def npmResult = system.run_command("npm --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        if (npmResult != 0) {
-            context?.echo("NodeAdapter: npm not found in PATH")
+        // lockfile-based package manager detection
+        def yarnLock = system.run_command("test -f yarn.lock", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def pnpmLock = system.run_command("test -f pnpm-lock.yaml", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (yarnLock == 0) {
+            packageManager = "yarn"
+        } else if (pnpmLock == 0) {
+            packageManager = "pnpm"
+        } else {
+            packageManager = "npm"
+        }
+
+        def pmResult = system.run_command("${packageManager} --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (pmResult != 0) {
+            context?.echo("NodeAdapter: ${packageManager} not found in PATH")
             return false
         }
 
@@ -43,10 +56,10 @@ class NodeAdapter implements BuildAdapter {
 
     @Override
     boolean lint(Map buildConfig) {
-        String lintCmd = buildConfig.lint_command ?: config?.lintCommand ?: "npm run lint"
+        String lintCmd = buildConfig.lint_command ?: config?.lintCommand ?: "${packageManager} run lint"
 
         def result = null
-        context?.withEnv(["CIORCH_LINT_CMD=${lintCmd}"]) {
+        context?.withEnv(["CIORCH_CMD=${lintCmd}"]) {
             result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
@@ -60,7 +73,7 @@ class NodeAdapter implements BuildAdapter {
 
     @Override
     boolean test(Map buildConfig) {
-        String testCmd = buildConfig.test_command ?: config?.testCommand ?: "npm test"
+        String testCmd = buildConfig.test_command ?: config?.testCommand ?: "${packageManager} test"
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
@@ -73,7 +86,7 @@ class NodeAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
-        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "npm run build"
+        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "${packageManager} run build"
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {

--- a/src/io/ciorch/build/adapters/NodeAdapter.groovy
+++ b/src/io/ciorch/build/adapters/NodeAdapter.groovy
@@ -43,7 +43,7 @@ class NodeAdapter implements BuildAdapter {
 
     @Override
     boolean lint(Map buildConfig) {
-        String lintCmd = buildConfig.lintCommand ?: "npm run lint"
+        String lintCmd = buildConfig.lint_command ?: buildConfig.lintCommand ?: "npm run lint"
 
         // Check whether the lint script exists in package.json (non-fatal if not available)
         def checkResult = system.run_command(
@@ -58,8 +58,8 @@ class NodeAdapter implements BuildAdapter {
         if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result != 0) {
-            context?.echo("NodeAdapter: lint command returned non-zero, skipping (non-fatal)")
-            return true
+            context?.echo("NodeAdapter: lint failed")
+            return false
         }
         return true
     }

--- a/src/io/ciorch/build/adapters/NodeAdapter.groovy
+++ b/src/io/ciorch/build/adapters/NodeAdapter.groovy
@@ -31,7 +31,7 @@ class NodeAdapter implements BuildAdapter {
 
         String nodeVersion = buildConfig.node_version ?: config?.toolVersions?.node_version
         if (nodeVersion) {
-            context?.echo("NodeAdapter: requested node_version=${nodeVersion}")
+            context?.echo("NodeAdapter: requested node_version=${nodeVersion} (informational only)")
         }
 
         // lockfile-based package manager detection

--- a/src/io/ciorch/build/adapters/NodeAdapter.groovy
+++ b/src/io/ciorch/build/adapters/NodeAdapter.groovy
@@ -43,17 +43,11 @@ class NodeAdapter implements BuildAdapter {
 
     @Override
     boolean lint(Map buildConfig) {
-        String lintCmd = buildConfig.lint_command ?: buildConfig.lintCommand ?: "npm run lint"
-
-        // Check whether the lint script exists in package.json (non-fatal if not available)
-        def checkResult = system.run_command(
-            'npm run lint --dry-run 2>/dev/null || npm run lint -- --help 2>/dev/null; true',
-            SystemCall.SHOW_COMMAND_STATUS_VALUE
-        )
+        String lintCmd = buildConfig.lint_command ?: config?.lintCommand ?: "npm run lint"
 
         def result = null
         context?.withEnv(["CIORCH_LINT_CMD=${lintCmd}"]) {
-            result = system.run_command('eval "$CIORCH_LINT_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
@@ -66,11 +60,11 @@ class NodeAdapter implements BuildAdapter {
 
     @Override
     boolean test(Map buildConfig) {
-        String testCmd = buildConfig.test_command ?: "npm test"
+        String testCmd = buildConfig.test_command ?: config?.testCommand ?: "npm test"
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
@@ -79,11 +73,11 @@ class NodeAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
-        String buildCmd = buildConfig.build_command ?: "npm run build"
+        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "npm run build"
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 

--- a/src/io/ciorch/build/adapters/NodeAdapter.groovy
+++ b/src/io/ciorch/build/adapters/NodeAdapter.groovy
@@ -1,0 +1,106 @@
+package io.ciorch.build.adapters
+
+import java.io.Serializable
+import io.ciorch.build.BuildAdapter
+import io.ciorch.core.SystemCall
+import io.ciorch.core.Config
+
+class NodeAdapter implements BuildAdapter {
+    def context = null
+    SystemCall system = null
+    Config config = null
+
+    private List<String> artifacts = []
+
+    NodeAdapter(def context, SystemCall system, Config cfg = null) {
+        this.context = context
+        this.system = system
+        this.config = cfg
+    }
+
+    @Override
+    boolean prepare(Map buildConfig, def ctx) {
+        this.context = ctx ?: this.context
+
+        def result = system.run_command("node --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (result != 0) {
+            context?.echo("NodeAdapter: node not found in PATH")
+            return false
+        }
+
+        if (buildConfig.node_version) {
+            context?.echo("NodeAdapter: requested node_version=${buildConfig.node_version}")
+        }
+
+        def npmResult = system.run_command("npm --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (npmResult != 0) {
+            context?.echo("NodeAdapter: npm not found in PATH")
+            return false
+        }
+
+        return true
+    }
+
+    @Override
+    boolean lint(Map buildConfig) {
+        String lintCmd = buildConfig.lintCommand ?: "npm run lint"
+
+        // Check whether the lint script exists in package.json (non-fatal if not available)
+        def checkResult = system.run_command(
+            'npm run lint --dry-run 2>/dev/null || npm run lint -- --help 2>/dev/null; true',
+            SystemCall.SHOW_COMMAND_STATUS_VALUE
+        )
+
+        def result = null
+        context?.withEnv(["CIORCH_LINT_CMD=${lintCmd}"]) {
+            result = system.run_command('eval "$CIORCH_LINT_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = checkResult
+
+        if (result != 0) {
+            context?.echo("NodeAdapter: lint command returned non-zero, skipping (non-fatal)")
+            return true
+        }
+        return true
+    }
+
+    @Override
+    boolean test(Map buildConfig) {
+        String testCmd = buildConfig.test_command ?: "npm test"
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        return result == 0
+    }
+
+    @Override
+    boolean build(Map buildConfig) {
+        String buildCmd = buildConfig.build_command ?: "npm run build"
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        if (result == 0) {
+            artifacts = ["dist/"]
+            return true
+        }
+        return false
+    }
+
+    @Override
+    List<String> getArtifacts() {
+        return artifacts
+    }
+
+    @Override
+    String getName() {
+        return "node"
+    }
+}

--- a/src/io/ciorch/build/adapters/NodeAdapter.groovy
+++ b/src/io/ciorch/build/adapters/NodeAdapter.groovy
@@ -55,7 +55,7 @@ class NodeAdapter implements BuildAdapter {
         context?.withEnv(["CIORCH_LINT_CMD=${lintCmd}"]) {
             result = system.run_command('eval "$CIORCH_LINT_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
-        if (result == null) result = checkResult
+        if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result != 0) {
             context?.echo("NodeAdapter: lint command returned non-zero, skipping (non-fatal)")
@@ -72,7 +72,7 @@ class NodeAdapter implements BuildAdapter {
         context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
             result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
-        if (result == null) result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         return result == 0
     }
@@ -85,7 +85,7 @@ class NodeAdapter implements BuildAdapter {
         context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
             result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
-        if (result == null) result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
             artifacts = ["dist/"]

--- a/src/io/ciorch/build/adapters/NodeAdapter.groovy
+++ b/src/io/ciorch/build/adapters/NodeAdapter.groovy
@@ -78,16 +78,44 @@ class NodeAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
-        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "${packageManager} run build"
+        String defaultBuildCmd = "${packageManager} run build"
+        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: defaultBuildCmd
+        boolean usingDefaultBuildCmd = (buildCmd == defaultBuildCmd)
+        List<String> configuredArtifacts = resolveConfiguredArtifacts(buildConfig)
         artifacts = []
 
         def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
-            artifacts = ["dist/"]
+            if (!configuredArtifacts.isEmpty()) {
+                artifacts = configuredArtifacts
+            } else if (usingDefaultBuildCmd) {
+                artifacts = ["dist/"]
+            }
             return true
         }
         return false
+    }
+
+    private List<String> resolveConfiguredArtifacts(Map buildConfig) {
+        def configuredArtifacts = buildConfig?.artifacts
+        if (configuredArtifacts == null) {
+            configuredArtifacts = config?.raw?.ciorch?.build?.artifacts
+        }
+
+        if (configuredArtifacts == null) {
+            return []
+        }
+
+        if (configuredArtifacts instanceof CharSequence) {
+            return [configuredArtifacts.toString()]
+        }
+
+        if (configuredArtifacts instanceof Collection) {
+            return configuredArtifacts.collect { it?.toString() }.findAll { it }
+        }
+
+        return [configuredArtifacts.toString()]
     }
 
     @Override

--- a/src/io/ciorch/build/adapters/NodeAdapter.groovy
+++ b/src/io/ciorch/build/adapters/NodeAdapter.groovy
@@ -58,11 +58,7 @@ class NodeAdapter implements BuildAdapter {
     boolean lint(Map buildConfig) {
         String lintCmd = buildConfig.lint_command ?: config?.lintCommand ?: "${packageManager} run lint"
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${lintCmd}"]) {
-            result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(lintCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result != 0) {
             context?.echo("NodeAdapter: lint failed")
@@ -75,11 +71,7 @@ class NodeAdapter implements BuildAdapter {
     boolean test(Map buildConfig) {
         String testCmd = buildConfig.test_command ?: config?.testCommand ?: "${packageManager} test"
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         return result == 0
     }
@@ -88,11 +80,7 @@ class NodeAdapter implements BuildAdapter {
     boolean build(Map buildConfig) {
         String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "${packageManager} run build"
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
             artifacts = ["dist/"]

--- a/src/io/ciorch/build/adapters/NodeAdapter.groovy
+++ b/src/io/ciorch/build/adapters/NodeAdapter.groovy
@@ -79,6 +79,7 @@ class NodeAdapter implements BuildAdapter {
     @Override
     boolean build(Map buildConfig) {
         String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "${packageManager} run build"
+        artifacts = []
 
         def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 

--- a/src/io/ciorch/build/adapters/PhpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PhpAdapter.groovy
@@ -47,6 +47,11 @@ class PhpAdapter implements BuildAdapter {
                 return false
             }
         } else {
+            def srcCheck = system.run_command("test -d src", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (srcCheck != 0) {
+                context?.echo("PhpAdapter: src/ not found, skipping php -l fallback")
+                return true
+            }
             // php -l requires individual files; iterate all .php files under src/
             context?.echo("PhpAdapter: vendor/bin/phpcs not found, falling back to php -l on src/ files")
             def result = system.run_command(

--- a/src/io/ciorch/build/adapters/PhpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PhpAdapter.groovy
@@ -1,0 +1,99 @@
+package io.ciorch.build.adapters
+
+import java.io.Serializable
+import io.ciorch.build.BuildAdapter
+import io.ciorch.core.SystemCall
+import io.ciorch.core.Config
+
+class PhpAdapter implements BuildAdapter {
+    def context = null
+    SystemCall system = null
+    Config config = null
+
+    private List<String> artifacts = []
+
+    PhpAdapter(def context, SystemCall system, Config cfg = null) {
+        this.context = context
+        this.system = system
+        this.config = cfg
+    }
+
+    @Override
+    boolean prepare(Map buildConfig, def ctx) {
+        this.context = ctx ?: this.context
+
+        def phpResult = system.run_command("php --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (phpResult != 0) {
+            context?.echo("PhpAdapter: php not found in PATH")
+            return false
+        }
+
+        def composerResult = system.run_command("composer --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (composerResult != 0) {
+            context?.echo("PhpAdapter: composer not found in PATH")
+            return false
+        }
+
+        return true
+    }
+
+    @Override
+    boolean lint(Map buildConfig) {
+        def phpcsCheck = system.run_command("test -x vendor/bin/phpcs", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (phpcsCheck == 0) {
+            def result = system.run_command("vendor/bin/phpcs", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (result != 0) {
+                context?.echo("PhpAdapter: phpcs returned non-zero, skipping (non-fatal)")
+                return true
+            }
+        } else {
+            context?.echo("PhpAdapter: vendor/bin/phpcs not found, falling back to php -l src/")
+            def result = system.run_command("php -l src/", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (result != 0) {
+                context?.echo("PhpAdapter: php -l src/ failed, skipping (non-fatal)")
+                return true
+            }
+        }
+        return true
+    }
+
+    @Override
+    boolean test(Map buildConfig) {
+        String testCmd = buildConfig.test_command ?: "vendor/bin/phpunit"
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        return result == 0
+    }
+
+    @Override
+    boolean build(Map buildConfig) {
+        String buildCmd = buildConfig.build_command ?: "composer install --no-dev --optimize-autoloader"
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        if (result == 0) {
+            artifacts = ["vendor/"]
+            return true
+        }
+        return false
+    }
+
+    @Override
+    List<String> getArtifacts() {
+        return artifacts
+    }
+
+    @Override
+    String getName() {
+        return "php"
+    }
+}

--- a/src/io/ciorch/build/adapters/PhpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PhpAdapter.groovy
@@ -39,6 +39,20 @@ class PhpAdapter implements BuildAdapter {
 
     @Override
     boolean lint(Map buildConfig) {
+        String overrideCmd = buildConfig.lint_command ?: config?.lintCommand
+        if (overrideCmd) {
+            def result = null
+            context?.withEnv(["CIORCH_CMD=${overrideCmd}"]) {
+                result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            }
+            if (result == null) result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (result != 0) {
+                context?.echo("PhpAdapter: lint failed")
+                return false
+            }
+            return true
+        }
+
         def phpcsCheck = system.run_command("test -x vendor/bin/phpcs", SystemCall.SHOW_COMMAND_STATUS_VALUE)
         if (phpcsCheck == 0) {
             def result = system.run_command("vendor/bin/phpcs", SystemCall.SHOW_COMMAND_STATUS_VALUE)

--- a/src/io/ciorch/build/adapters/PhpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PhpAdapter.groovy
@@ -65,7 +65,7 @@ class PhpAdapter implements BuildAdapter {
         context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
             result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
-        if (result == null) result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         return result == 0
     }
@@ -78,7 +78,7 @@ class PhpAdapter implements BuildAdapter {
         context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
             result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
-        if (result == null) result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
             artifacts = ["vendor/"]

--- a/src/io/ciorch/build/adapters/PhpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PhpAdapter.groovy
@@ -47,8 +47,12 @@ class PhpAdapter implements BuildAdapter {
                 return false
             }
         } else {
-            context?.echo("PhpAdapter: vendor/bin/phpcs not found, falling back to php -l src/")
-            def result = system.run_command("php -l src/", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            // php -l requires individual files; iterate all .php files under src/
+            context?.echo("PhpAdapter: vendor/bin/phpcs not found, falling back to php -l on src/ files")
+            def result = system.run_command(
+                "find src -name '*.php' -print0 | xargs -0 -r php -l",
+                SystemCall.SHOW_COMMAND_STATUS_VALUE
+            )
             if (result != 0) {
                 context?.echo("PhpAdapter: lint failed")
                 return false
@@ -59,11 +63,11 @@ class PhpAdapter implements BuildAdapter {
 
     @Override
     boolean test(Map buildConfig) {
-        String testCmd = buildConfig.test_command ?: "vendor/bin/phpunit"
+        String testCmd = buildConfig.test_command ?: config?.testCommand ?: "vendor/bin/phpunit"
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
@@ -72,11 +76,11 @@ class PhpAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
-        String buildCmd = buildConfig.build_command ?: "composer install --no-dev --optimize-autoloader"
+        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "composer install --no-dev --optimize-autoloader"
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 

--- a/src/io/ciorch/build/adapters/PhpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PhpAdapter.groovy
@@ -43,15 +43,15 @@ class PhpAdapter implements BuildAdapter {
         if (phpcsCheck == 0) {
             def result = system.run_command("vendor/bin/phpcs", SystemCall.SHOW_COMMAND_STATUS_VALUE)
             if (result != 0) {
-                context?.echo("PhpAdapter: phpcs returned non-zero, skipping (non-fatal)")
-                return true
+                context?.echo("PhpAdapter: lint failed")
+                return false
             }
         } else {
             context?.echo("PhpAdapter: vendor/bin/phpcs not found, falling back to php -l src/")
             def result = system.run_command("php -l src/", SystemCall.SHOW_COMMAND_STATUS_VALUE)
             if (result != 0) {
-                context?.echo("PhpAdapter: php -l src/ failed, skipping (non-fatal)")
-                return true
+                context?.echo("PhpAdapter: lint failed")
+                return false
             }
         }
         return true

--- a/src/io/ciorch/build/adapters/PhpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PhpAdapter.groovy
@@ -57,15 +57,10 @@ class PhpAdapter implements BuildAdapter {
                 return false
             }
         } else {
-            def srcCheck = system.run_command("test -d src", SystemCall.SHOW_COMMAND_STATUS_VALUE)
-            if (srcCheck != 0) {
-                context?.echo("PhpAdapter: src/ not found, skipping php -l fallback")
-                return true
-            }
-            // php -l requires individual files; iterate all .php files under src/
-            context?.echo("PhpAdapter: vendor/bin/phpcs not found, falling back to php -l on src/ files")
+            // php -l requires individual files; scan the repository while skipping vendor dependencies.
+            context?.echo("PhpAdapter: vendor/bin/phpcs not found, falling back to php -l on repository PHP files")
             def result = system.run_command(
-                "find src -type f -name '*.php' -exec sh -c 'for f do php -l \"\$f\" || exit 1; done' sh {} +",
+                "find . -path ./vendor -prune -o -type f -name '*.php' -exec sh -c 'for f do php -l \"\$f\" || exit 1; done' sh {} +",
                 SystemCall.SHOW_COMMAND_STATUS_VALUE
             )
             if (result != 0) {

--- a/src/io/ciorch/build/adapters/PhpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PhpAdapter.groovy
@@ -41,11 +41,7 @@ class PhpAdapter implements BuildAdapter {
     boolean lint(Map buildConfig) {
         String overrideCmd = buildConfig.lint_command ?: config?.lintCommand
         if (overrideCmd) {
-            def result = null
-            context?.withEnv(["CIORCH_CMD=${overrideCmd}"]) {
-                result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-            }
-            if (result == null) result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            def result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
             if (result != 0) {
                 context?.echo("PhpAdapter: lint failed")
                 return false
@@ -84,11 +80,7 @@ class PhpAdapter implements BuildAdapter {
     boolean test(Map buildConfig) {
         String testCmd = buildConfig.test_command ?: config?.testCommand ?: "vendor/bin/phpunit"
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         return result == 0
     }
@@ -97,11 +89,7 @@ class PhpAdapter implements BuildAdapter {
     boolean build(Map buildConfig) {
         String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "composer install --no-dev --optimize-autoloader"
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
             artifacts = ["vendor/"]

--- a/src/io/ciorch/build/adapters/PhpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PhpAdapter.groovy
@@ -69,7 +69,7 @@ class PhpAdapter implements BuildAdapter {
             // php -l requires individual files; iterate all .php files under src/
             context?.echo("PhpAdapter: vendor/bin/phpcs not found, falling back to php -l on src/ files")
             def result = system.run_command(
-                "find src -name '*.php' -print0 | xargs -0 -r php -l",
+                "find src -type f -name '*.php' -exec sh -c 'for f do php -l \"\$f\" || exit 1; done' sh {} +",
                 SystemCall.SHOW_COMMAND_STATUS_VALUE
             )
             if (result != 0) {

--- a/src/io/ciorch/build/adapters/PhpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PhpAdapter.groovy
@@ -88,6 +88,7 @@ class PhpAdapter implements BuildAdapter {
     @Override
     boolean build(Map buildConfig) {
         String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "composer install --no-dev --optimize-autoloader"
+        artifacts = []
 
         def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 

--- a/src/io/ciorch/build/adapters/PhpAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PhpAdapter.groovy
@@ -87,16 +87,39 @@ class PhpAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
-        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "composer install --no-dev --optimize-autoloader"
+        String defaultBuildCmd = "composer install --no-dev --optimize-autoloader"
+        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: defaultBuildCmd
         artifacts = []
 
         def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
-            artifacts = ["vendor/"]
+            artifacts = resolveArtifacts(buildConfig, buildCmd, defaultBuildCmd)
             return true
         }
         return false
+    }
+
+    private List<String> resolveArtifacts(Map buildConfig, String buildCmd, String defaultBuildCmd) {
+        Map rawBuild = (config?.raw?.ciorch?.build ?: [:]) as Map
+        List<String> configuredArtifacts = normalizeArtifacts(buildConfig?.artifacts ?: rawBuild.artifacts)
+        if (configuredArtifacts) {
+            return configuredArtifacts
+        }
+
+        return (buildCmd == defaultBuildCmd) ? ["vendor/"] : []
+    }
+
+    private List<String> normalizeArtifacts(def configuredArtifacts) {
+        if (!configuredArtifacts) {
+            return []
+        }
+
+        if (configuredArtifacts instanceof Collection) {
+            return configuredArtifacts.collect { it?.toString() }.findAll { it }
+        }
+
+        return [configuredArtifacts.toString()]
     }
 
     @Override

--- a/src/io/ciorch/build/adapters/PythonAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PythonAdapter.groovy
@@ -1,0 +1,132 @@
+package io.ciorch.build.adapters
+
+import java.io.Serializable
+import io.ciorch.build.BuildAdapter
+import io.ciorch.core.SystemCall
+import io.ciorch.core.Config
+
+class PythonAdapter implements BuildAdapter {
+    def context = null
+    SystemCall system = null
+    Config config = null
+
+    String packageManager = "pip"
+
+    private List<String> artifacts = []
+
+    PythonAdapter(def context, SystemCall system, Config cfg = null) {
+        this.context = context
+        this.system = system
+        this.config = cfg
+    }
+
+    @Override
+    boolean prepare(Map buildConfig, def ctx) {
+        this.context = ctx ?: this.context
+
+        def result = system.run_command("python3 --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (result != 0) {
+            result = system.run_command("python --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (result != 0) {
+                context?.echo("PythonAdapter: python3/python not found in PATH")
+                return false
+            }
+        }
+
+        // Detect package manager
+        def hasPoetryLock = system.run_command("test -f pyproject.toml && test -f poetry.lock", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (hasPoetryLock == 0) {
+            this.packageManager = "poetry"
+            context?.echo("PythonAdapter: detected package manager: poetry")
+        } else {
+            def hasUvLock = system.run_command("test -f pyproject.toml && test -f uv.lock", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (hasUvLock == 0) {
+                this.packageManager = "uv"
+                context?.echo("PythonAdapter: detected package manager: uv")
+            } else {
+                this.packageManager = "pip"
+                context?.echo("PythonAdapter: detected package manager: pip")
+            }
+        }
+
+        return true
+    }
+
+    @Override
+    boolean lint(Map buildConfig) {
+        def ruffCheck = system.run_command("which ruff", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (ruffCheck == 0) {
+            def result = system.run_command("ruff check .", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (result != 0) {
+                context?.echo("PythonAdapter: ruff check failed")
+                return false
+            }
+            return true
+        }
+
+        def flake8Check = system.run_command("which flake8", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (flake8Check == 0) {
+            def result = system.run_command("flake8 .", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (result != 0) {
+                context?.echo("PythonAdapter: flake8 failed")
+                return false
+            }
+            return true
+        }
+
+        context?.echo("PythonAdapter: no linter found (ruff, flake8), skipping lint (non-fatal)")
+        return true
+    }
+
+    @Override
+    boolean test(Map buildConfig) {
+        String testCmd = buildConfig.test_command ?: "python -m pytest"
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        return result == 0
+    }
+
+    @Override
+    boolean build(Map buildConfig) {
+        String defaultCmd = null
+        if (buildConfig.build_command) {
+            defaultCmd = buildConfig.build_command
+        } else if (packageManager == "poetry") {
+            defaultCmd = "poetry build"
+        } else if (packageManager == "uv") {
+            defaultCmd = "uv build"
+        } else {
+            // pip: no-op
+            context?.echo("PythonAdapter: pip build — no distribution build step, skipping")
+            artifacts = ["dist/"]
+            return true
+        }
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${defaultCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(defaultCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        if (result == 0) {
+            artifacts = ["dist/"]
+            return true
+        }
+        return false
+    }
+
+    @Override
+    List<String> getArtifacts() {
+        return artifacts
+    }
+
+    @Override
+    String getName() {
+        return "python"
+    }
+}

--- a/src/io/ciorch/build/adapters/PythonAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PythonAdapter.groovy
@@ -11,6 +11,7 @@ class PythonAdapter implements BuildAdapter {
     Config config = null
 
     String packageManager = "pip"
+    private String pythonCmd = "python3"
 
     private List<String> artifacts = []
 
@@ -31,6 +32,9 @@ class PythonAdapter implements BuildAdapter {
                 context?.echo("PythonAdapter: python3/python not found in PATH")
                 return false
             }
+            this.pythonCmd = "python"
+        } else {
+            this.pythonCmd = "python3"
         }
 
         // Detect package manager
@@ -80,7 +84,7 @@ class PythonAdapter implements BuildAdapter {
 
     @Override
     boolean test(Map buildConfig) {
-        String testCmd = buildConfig.test_command ?: "python -m pytest"
+        String testCmd = buildConfig.test_command ?: "${pythonCmd} -m pytest"
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
@@ -103,7 +107,6 @@ class PythonAdapter implements BuildAdapter {
         } else {
             // pip: no-op
             context?.echo("PythonAdapter: pip build — no distribution build step, skipping")
-            artifacts = ["dist/"]
             return true
         }
 

--- a/src/io/ciorch/build/adapters/PythonAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PythonAdapter.groovy
@@ -58,6 +58,20 @@ class PythonAdapter implements BuildAdapter {
 
     @Override
     boolean lint(Map buildConfig) {
+        String overrideCmd = buildConfig.lint_command ?: config?.lintCommand
+        if (overrideCmd) {
+            def result = null
+            context?.withEnv(["CIORCH_CMD=${overrideCmd}"]) {
+                result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            }
+            if (result == null) result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (result != 0) {
+                context?.echo("PythonAdapter: lint failed")
+                return false
+            }
+            return true
+        }
+
         def ruffCheck = system.run_command("which ruff", SystemCall.SHOW_COMMAND_STATUS_VALUE)
         if (ruffCheck == 0) {
             def result = system.run_command("ruff check .", SystemCall.SHOW_COMMAND_STATUS_VALUE)

--- a/src/io/ciorch/build/adapters/PythonAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PythonAdapter.groovy
@@ -84,11 +84,11 @@ class PythonAdapter implements BuildAdapter {
 
     @Override
     boolean test(Map buildConfig) {
-        String testCmd = buildConfig.test_command ?: "${pythonCmd} -m pytest"
+        String testCmd = buildConfig.test_command ?: config?.testCommand ?: "${pythonCmd} -m pytest"
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
@@ -100,6 +100,8 @@ class PythonAdapter implements BuildAdapter {
         String defaultCmd = null
         if (buildConfig.build_command) {
             defaultCmd = buildConfig.build_command
+        } else if (config?.buildCommand) {
+            defaultCmd = config.buildCommand
         } else if (packageManager == "poetry") {
             defaultCmd = "poetry build"
         } else if (packageManager == "uv") {
@@ -112,7 +114,7 @@ class PythonAdapter implements BuildAdapter {
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${defaultCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(defaultCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(defaultCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 

--- a/src/io/ciorch/build/adapters/PythonAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PythonAdapter.groovy
@@ -60,11 +60,7 @@ class PythonAdapter implements BuildAdapter {
     boolean lint(Map buildConfig) {
         String overrideCmd = buildConfig.lint_command ?: config?.lintCommand
         if (overrideCmd) {
-            def result = null
-            context?.withEnv(["CIORCH_CMD=${overrideCmd}"]) {
-                result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-            }
-            if (result == null) result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            def result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
             if (result != 0) {
                 context?.echo("PythonAdapter: lint failed")
                 return false
@@ -100,11 +96,7 @@ class PythonAdapter implements BuildAdapter {
     boolean test(Map buildConfig) {
         String testCmd = buildConfig.test_command ?: config?.testCommand ?: "${pythonCmd} -m pytest"
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         return result == 0
     }
@@ -126,11 +118,7 @@ class PythonAdapter implements BuildAdapter {
             return true
         }
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${defaultCmd}"]) {
-            result = system.run_command(defaultCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(defaultCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(defaultCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
             artifacts = ["dist/"]

--- a/src/io/ciorch/build/adapters/PythonAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PythonAdapter.groovy
@@ -115,6 +115,7 @@ class PythonAdapter implements BuildAdapter {
         } else {
             // pip: no-op
             context?.echo("PythonAdapter: pip build — no distribution build step, skipping")
+            artifacts = []
             return true
         }
 
@@ -124,6 +125,7 @@ class PythonAdapter implements BuildAdapter {
             artifacts = ["dist/"]
             return true
         }
+        artifacts = []
         return false
     }
 

--- a/src/io/ciorch/build/adapters/PythonAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PythonAdapter.groovy
@@ -40,11 +40,21 @@ class PythonAdapter implements BuildAdapter {
         // Detect package manager
         def hasPoetryLock = system.run_command("test -f pyproject.toml && test -f poetry.lock", SystemCall.SHOW_COMMAND_STATUS_VALUE)
         if (hasPoetryLock == 0) {
+            def poetryResult = system.run_command("poetry --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (poetryResult != 0) {
+                context?.echo("PythonAdapter: poetry.lock found but poetry is not in PATH")
+                return false
+            }
             this.packageManager = "poetry"
             context?.echo("PythonAdapter: detected package manager: poetry")
         } else {
             def hasUvLock = system.run_command("test -f pyproject.toml && test -f uv.lock", SystemCall.SHOW_COMMAND_STATUS_VALUE)
             if (hasUvLock == 0) {
+                def uvResult = system.run_command("uv --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+                if (uvResult != 0) {
+                    context?.echo("PythonAdapter: uv.lock found but uv is not in PATH")
+                    return false
+                }
                 this.packageManager = "uv"
                 context?.echo("PythonAdapter: detected package manager: uv")
             } else {

--- a/src/io/ciorch/build/adapters/PythonAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PythonAdapter.groovy
@@ -113,26 +113,24 @@ class PythonAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
-        String defaultCmd = null
-        boolean usingDefaultBuild = false
-        if (buildConfig.build_command) {
-            defaultCmd = buildConfig.build_command
-        } else if (config?.buildCommand) {
-            defaultCmd = config.buildCommand
-        } else if (packageManager == "poetry") {
-            defaultCmd = "poetry build"
-            usingDefaultBuild = true
+        String defaultBuildCmd = null
+        if (packageManager == "poetry") {
+            defaultBuildCmd = "poetry build"
         } else if (packageManager == "uv") {
-            defaultCmd = "uv build"
-            usingDefaultBuild = true
-        } else {
+            defaultBuildCmd = "uv build"
+        }
+
+        if (!defaultBuildCmd && !buildConfig.build_command && !config?.buildCommand) {
             // pip: no-op
             context?.echo("PythonAdapter: pip build — no distribution build step, skipping")
             artifacts = []
             return true
         }
 
-        def result = system.run_command(defaultCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: defaultBuildCmd
+        boolean usingDefaultBuild = (buildCmd == defaultBuildCmd)
+
+        def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
             artifacts = resolveArtifacts(buildConfig, usingDefaultBuild)

--- a/src/io/ciorch/build/adapters/PythonAdapter.groovy
+++ b/src/io/ciorch/build/adapters/PythonAdapter.groovy
@@ -104,14 +104,17 @@ class PythonAdapter implements BuildAdapter {
     @Override
     boolean build(Map buildConfig) {
         String defaultCmd = null
+        boolean usingDefaultBuild = false
         if (buildConfig.build_command) {
             defaultCmd = buildConfig.build_command
         } else if (config?.buildCommand) {
             defaultCmd = config.buildCommand
         } else if (packageManager == "poetry") {
             defaultCmd = "poetry build"
+            usingDefaultBuild = true
         } else if (packageManager == "uv") {
             defaultCmd = "uv build"
+            usingDefaultBuild = true
         } else {
             // pip: no-op
             context?.echo("PythonAdapter: pip build — no distribution build step, skipping")
@@ -122,11 +125,33 @@ class PythonAdapter implements BuildAdapter {
         def result = system.run_command(defaultCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
-            artifacts = ["dist/"]
+            artifacts = resolveArtifacts(buildConfig, usingDefaultBuild)
             return true
         }
         artifacts = []
         return false
+    }
+
+    private List<String> resolveArtifacts(Map buildConfig, boolean usingDefaultBuild) {
+        Map rawBuild = (config?.raw?.ciorch?.build ?: [:]) as Map
+        List<String> configuredArtifacts = normalizeArtifacts(buildConfig?.artifacts ?: rawBuild.artifacts)
+        if (configuredArtifacts) {
+            return configuredArtifacts
+        }
+
+        return usingDefaultBuild ? ["dist/"] : []
+    }
+
+    private List<String> normalizeArtifacts(def configuredArtifacts) {
+        if (!configuredArtifacts) {
+            return []
+        }
+
+        if (configuredArtifacts instanceof Collection) {
+            return configuredArtifacts.collect { it?.toString() }.findAll { it }
+        }
+
+        return [configuredArtifacts.toString()]
     }
 
     @Override

--- a/src/io/ciorch/build/adapters/RustAdapter.groovy
+++ b/src/io/ciorch/build/adapters/RustAdapter.groovy
@@ -39,6 +39,20 @@ class RustAdapter implements BuildAdapter {
 
     @Override
     boolean lint(Map buildConfig) {
+        String overrideCmd = buildConfig.lint_command ?: config?.lintCommand
+        if (overrideCmd) {
+            def result = null
+            context?.withEnv(["CIORCH_CMD=${overrideCmd}"]) {
+                result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            }
+            if (result == null) result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (result != 0) {
+                context?.echo("RustAdapter: lint failed")
+                return false
+            }
+            return true
+        }
+
         def clippyResult = system.run_command("cargo clippy -- -D warnings", SystemCall.SHOW_COMMAND_STATUS_VALUE)
         if (clippyResult != 0) {
             context?.echo("RustAdapter: cargo clippy failed")

--- a/src/io/ciorch/build/adapters/RustAdapter.groovy
+++ b/src/io/ciorch/build/adapters/RustAdapter.groovy
@@ -61,11 +61,11 @@ class RustAdapter implements BuildAdapter {
 
     @Override
     boolean test(Map buildConfig) {
-        String testCmd = buildConfig.test_command ?: "cargo test"
+        String testCmd = buildConfig.test_command ?: config?.testCommand ?: "cargo test"
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
@@ -74,11 +74,11 @@ class RustAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
-        String buildCmd = buildConfig.build_command ?: "cargo build --release"
+        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "cargo build --release"
 
         def result = null
         context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
         }
         if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 

--- a/src/io/ciorch/build/adapters/RustAdapter.groovy
+++ b/src/io/ciorch/build/adapters/RustAdapter.groovy
@@ -1,0 +1,101 @@
+package io.ciorch.build.adapters
+
+import java.io.Serializable
+import io.ciorch.build.BuildAdapter
+import io.ciorch.core.SystemCall
+import io.ciorch.core.Config
+
+class RustAdapter implements BuildAdapter {
+    def context = null
+    SystemCall system = null
+    Config config = null
+
+    private List<String> artifacts = []
+
+    RustAdapter(def context, SystemCall system, Config cfg = null) {
+        this.context = context
+        this.system = system
+        this.config = cfg
+    }
+
+    @Override
+    boolean prepare(Map buildConfig, def ctx) {
+        this.context = ctx ?: this.context
+
+        def result = system.run_command("cargo --version", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (result != 0) {
+            context?.echo("RustAdapter: cargo not found in PATH")
+            return false
+        }
+
+        def fetchResult = system.run_command("cargo fetch", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (fetchResult != 0) {
+            context?.echo("RustAdapter: cargo fetch failed")
+            return false
+        }
+
+        return true
+    }
+
+    @Override
+    boolean lint(Map buildConfig) {
+        def clippyResult = system.run_command("cargo clippy -- -D warnings", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (clippyResult != 0) {
+            context?.echo("RustAdapter: cargo clippy failed")
+            return false
+        }
+
+        def fmtCheck = system.run_command("which rustfmt", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        if (fmtCheck == 0) {
+            def fmtResult = system.run_command("cargo fmt --check", SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            if (fmtResult != 0) {
+                context?.echo("RustAdapter: cargo fmt --check failed")
+                return false
+            }
+        } else {
+            context?.echo("RustAdapter: rustfmt not found, skipping cargo fmt --check (non-fatal)")
+        }
+
+        return true
+    }
+
+    @Override
+    boolean test(Map buildConfig) {
+        String testCmd = buildConfig.test_command ?: "cargo test"
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        return result == 0
+    }
+
+    @Override
+    boolean build(Map buildConfig) {
+        String buildCmd = buildConfig.build_command ?: "cargo build --release"
+
+        def result = null
+        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
+            result = system.run_command('eval "$CIORCH_CMD"', SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        }
+        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+
+        if (result == 0) {
+            artifacts = ["target/release/"]
+            return true
+        }
+        return false
+    }
+
+    @Override
+    List<String> getArtifacts() {
+        return artifacts
+    }
+
+    @Override
+    String getName() {
+        return "rust"
+    }
+}

--- a/src/io/ciorch/build/adapters/RustAdapter.groovy
+++ b/src/io/ciorch/build/adapters/RustAdapter.groovy
@@ -82,6 +82,7 @@ class RustAdapter implements BuildAdapter {
     boolean build(Map buildConfig) {
         String defaultBuildCmd = "cargo build --release"
         String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: defaultBuildCmd
+        artifacts = []
 
         def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 

--- a/src/io/ciorch/build/adapters/RustAdapter.groovy
+++ b/src/io/ciorch/build/adapters/RustAdapter.groovy
@@ -80,15 +80,42 @@ class RustAdapter implements BuildAdapter {
 
     @Override
     boolean build(Map buildConfig) {
-        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "cargo build --release"
+        String defaultBuildCmd = "cargo build --release"
+        String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: defaultBuildCmd
 
         def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
-            artifacts = ["target/release/"]
+            artifacts = resolveArtifacts(buildConfig, buildCmd, defaultBuildCmd)
             return true
         }
         return false
+    }
+
+    private List<String> resolveArtifacts(Map buildConfig, String buildCmd, String defaultBuildCmd) {
+        Map rawBuild = (config?.raw?.ciorch?.build ?: [:]) as Map
+        List<String> configuredArtifacts = normalizeArtifacts(buildConfig?.artifacts ?: rawBuild.artifacts)
+        if (configuredArtifacts) {
+            return configuredArtifacts
+        }
+
+        if (buildCmd == defaultBuildCmd) {
+            return ["target/release/"]
+        }
+
+        return []
+    }
+
+    private List<String> normalizeArtifacts(def configuredArtifacts) {
+        if (!configuredArtifacts) {
+            return []
+        }
+
+        if (configuredArtifacts instanceof Collection) {
+            return configuredArtifacts.collect { it?.toString() }.findAll { it }
+        }
+
+        return [configuredArtifacts.toString()]
     }
 
     @Override

--- a/src/io/ciorch/build/adapters/RustAdapter.groovy
+++ b/src/io/ciorch/build/adapters/RustAdapter.groovy
@@ -41,11 +41,7 @@ class RustAdapter implements BuildAdapter {
     boolean lint(Map buildConfig) {
         String overrideCmd = buildConfig.lint_command ?: config?.lintCommand
         if (overrideCmd) {
-            def result = null
-            context?.withEnv(["CIORCH_CMD=${overrideCmd}"]) {
-                result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-            }
-            if (result == null) result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+            def result = system.run_command(overrideCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
             if (result != 0) {
                 context?.echo("RustAdapter: lint failed")
                 return false
@@ -77,11 +73,7 @@ class RustAdapter implements BuildAdapter {
     boolean test(Map buildConfig) {
         String testCmd = buildConfig.test_command ?: config?.testCommand ?: "cargo test"
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${testCmd}"]) {
-            result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(testCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         return result == 0
     }
@@ -90,11 +82,7 @@ class RustAdapter implements BuildAdapter {
     boolean build(Map buildConfig) {
         String buildCmd = buildConfig.build_command ?: config?.buildCommand ?: "cargo build --release"
 
-        def result = null
-        context?.withEnv(["CIORCH_CMD=${buildCmd}"]) {
-            result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
-        }
-        if (result == null) result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
+        def result = system.run_command(buildCmd, SystemCall.SHOW_COMMAND_STATUS_VALUE)
 
         if (result == 0) {
             artifacts = ["target/release/"]

--- a/src/io/ciorch/core/Config.groovy
+++ b/src/io/ciorch/core/Config.groovy
@@ -21,7 +21,7 @@ class Config implements Serializable {
     Map deployEnvironments = [:]    // environment name → {host, user, path}
 
     // Branching
-    String branchingStrategy = "gitflow"  // gitflow|github-flow|trunk-based|custom
+    String branchingStrategy = "default-gitflow"  // default-gitflow|github-flow|trunk-based|custom
     String customMatrixPath = ""
 
     // Notifications
@@ -100,7 +100,7 @@ class Config implements Serializable {
         deployEnvironments = (deploy.environments ?: [:]) as Map
 
         Map branching = (ciorch.branching ?: [:]) as Map
-        branchingStrategy = (branching.strategy ?: "gitflow") as String
+        branchingStrategy = (branching.strategy ?: "default-gitflow") as String
         customMatrixPath = (branching.custom_matrix ?: "") as String
 
         Map notify = (ciorch.notify ?: [:]) as Map

--- a/src/io/ciorch/core/Config.groovy
+++ b/src/io/ciorch/core/Config.groovy
@@ -71,6 +71,7 @@ class Config implements Serializable {
     // Load from a Map directly (useful for testing)
     boolean loadMap(Map ciorch) {
         this.data = ciorch
+        this.raw = [ciorch: ciorch]
         _populate(ciorch)
         return true
     }
@@ -117,7 +118,9 @@ class Config implements Serializable {
 
     // Returns build config keys in the snake_case form adapters expect
     Map buildMap() {
-        Map m = [:]
+        Map m = ((data.build ?: [:]) as Map).findAll { k, v ->
+            !(k.toString() in ["adapter", "docker"])
+        }
         if (lintCommand)  m.lint_command  = lintCommand
         if (testCommand)  m.test_command  = testCommand
         if (buildCommand) m.build_command = buildCommand

--- a/src/io/ciorch/core/Config.groovy
+++ b/src/io/ciorch/core/Config.groovy
@@ -118,9 +118,11 @@ class Config implements Serializable {
 
     // Returns build config keys in the snake_case form adapters expect
     Map buildMap() {
-        Map m = ((data.build ?: [:]) as Map).findAll { k, v ->
-            !(k.toString() in ["adapter", "docker"])
-        }
+        Map build = (data.build ?: [:]) as Map
+        Map m = build.findAll { k, v -> k.toString() != "adapter" }
+        Map docker = (build.docker ?: [:]) as Map
+        m.remove("docker")
+        m.putAll(docker)
         if (lintCommand)  m.lint_command  = lintCommand
         if (testCommand)  m.test_command  = testCommand
         if (buildCommand) m.build_command = buildCommand

--- a/src/io/ciorch/core/Config.groovy
+++ b/src/io/ciorch/core/Config.groovy
@@ -115,6 +115,16 @@ class Config implements Serializable {
         platformOverrides = (ciorch.platform ?: [:]) as Map
     }
 
+    // Returns build config keys in the snake_case form adapters expect
+    Map buildMap() {
+        Map m = [:]
+        if (lintCommand)  m.lint_command  = lintCommand
+        if (testCommand)  m.test_command  = testCommand
+        if (buildCommand) m.build_command = buildCommand
+        m.putAll(toolVersions ?: [:])
+        return m
+    }
+
     // Get deploy environment config by name
     Map getEnvironment(String envName) {
         return (deployEnvironments[envName] ?: [:]) as Map

--- a/src/io/ciorch/core/PipelineOrchestrator.groovy
+++ b/src/io/ciorch/core/PipelineOrchestrator.groovy
@@ -45,6 +45,7 @@ class PipelineOrchestrator implements Serializable {
     // Runtime state
     GitEvent currentEvent = null
     List<String> pendingTasks = []
+    private BuildAdapter _cachedAdapter = null
 
     PipelineOrchestrator(def context, Config config, SystemCall system) {
         this.context = context
@@ -183,6 +184,8 @@ class PipelineOrchestrator implements Serializable {
     }
 
     private BuildAdapter _resolveBuildAdapter() {
+        if (_cachedAdapter != null) return _cachedAdapter
+
         String adapterName = config.buildAdapter ?: "docker"
         Class adapterClass = BUILD_REGISTRY[adapterName]
         if (!adapterClass) {
@@ -190,8 +193,12 @@ class PipelineOrchestrator implements Serializable {
             return null
         }
         BuildAdapter adapter = adapterClass.newInstance(context, system, config) as BuildAdapter
-        adapter.prepare([:], context)
-        return adapter
+        if (!adapter.prepare([:], context)) {
+            notifier.log("PipelineOrchestrator: adapter '${adapterName}' prepare() failed — aborting build steps", Notifier.ERROR)
+            return null
+        }
+        _cachedAdapter = adapter
+        return _cachedAdapter
     }
 
     private DeployAdapter _resolveDeployAdapter() {

--- a/src/io/ciorch/core/PipelineOrchestrator.groovy
+++ b/src/io/ciorch/core/PipelineOrchestrator.groovy
@@ -9,6 +9,15 @@ import io.ciorch.git.GitOperations
 import io.ciorch.git.TaskType
 import io.ciorch.build.BuildAdapter
 import io.ciorch.build.DockerAdapter
+import io.ciorch.build.adapters.NodeAdapter
+import io.ciorch.build.adapters.GoAdapter
+import io.ciorch.build.adapters.PhpAdapter
+import io.ciorch.build.adapters.PythonAdapter
+import io.ciorch.build.adapters.CSharpAdapter
+import io.ciorch.build.adapters.RustAdapter
+import io.ciorch.build.adapters.CppAdapter
+import io.ciorch.build.adapters.JavaAdapter
+import io.ciorch.build.adapters.GenericAdapter
 import io.ciorch.deploy.DeployAdapter
 
 class PipelineOrchestrator implements Serializable {
@@ -20,7 +29,16 @@ class PipelineOrchestrator implements Serializable {
 
     // Adapter registry: id → class (ConcurrentHashMap for parallel-pipeline safety)
     private static final Map<String, Class> BUILD_REGISTRY = new java.util.concurrent.ConcurrentHashMap<>([
-        docker: DockerAdapter
+        docker:  DockerAdapter,
+        node:    NodeAdapter,
+        go:      GoAdapter,
+        php:     PhpAdapter,
+        python:  PythonAdapter,
+        csharp:  CSharpAdapter,
+        rust:    RustAdapter,
+        cpp:     CppAdapter,
+        java:    JavaAdapter,
+        generic: GenericAdapter
     ])
     private static final Map<String, Class> DEPLOY_REGISTRY = new java.util.concurrent.ConcurrentHashMap<>()
 

--- a/src/io/ciorch/core/PipelineOrchestrator.groovy
+++ b/src/io/ciorch/core/PipelineOrchestrator.groovy
@@ -146,9 +146,9 @@ class PipelineOrchestrator implements Serializable {
         if (!adapter) return false
 
         switch (step) {
-            case TaskType.LINT: return adapter.lint([:])
-            case TaskType.TEST: return adapter.test([:])
-            case TaskType.BUILD: return adapter.build([:])
+            case TaskType.LINT: return adapter.lint(config.buildMap())
+            case TaskType.TEST: return adapter.test(config.buildMap())
+            case TaskType.BUILD: return adapter.build(config.buildMap())
             default: return true
         }
     }
@@ -193,7 +193,7 @@ class PipelineOrchestrator implements Serializable {
             return null
         }
         BuildAdapter adapter = adapterClass.newInstance(context, system, config) as BuildAdapter
-        if (!adapter.prepare([:], context)) {
+        if (!adapter.prepare(config.buildMap(), context)) {
             notifier.log("PipelineOrchestrator: adapter '${adapterName}' prepare() failed — aborting build steps", Notifier.ERROR)
             return null
         }

--- a/src/io/ciorch/git/WebhookParser.groovy
+++ b/src/io/ciorch/git/WebhookParser.groovy
@@ -1373,7 +1373,7 @@ class WebhookParser implements Serializable {
             return false
         }
 
-        if (this.isClosedPR || this.isForcedPush || this.isNewBranch || this.isOpenedPR || EventType.SYNC == this.actionType) {
+        if (this.isClosedPR || this.isForcedPush || this.isNewBranch || this.isOpenedPR || EventType.SYNC == this.actionType || this.isPush) {
             if (this.dstType in allowedList || allowedList.contains(this.dstType)) {
                 result = true
             }
@@ -1387,11 +1387,6 @@ class WebhookParser implements Serializable {
         // Closed PR without a merge => skip.
         if (EventType.CLOSED_PR == this.actionType && !this.isMerged) {
             result = false
-        }
-
-        // Push to environment branches is always processed.
-        if (this.dstType in [BranchType.ENV_DEV, BranchType.ENV_QA] && this.isPush) {
-            result = true
         }
 
         this.context.echo("** Process this job? Answer: ${result.toString()}" as String)

--- a/src/io/ciorch/git/WebhookParser.groovy
+++ b/src/io/ciorch/git/WebhookParser.groovy
@@ -1360,6 +1360,8 @@ class WebhookParser implements Serializable {
             BranchType.RELEASE,
             BranchType.DEVELOP,
             BranchType.MASTER,
+            BranchType.MAIN,
+            BranchType.TRUNK,
             BranchType.PLUGIN,
             BranchType.ENV_DEV,
             BranchType.ENV_QA,

--- a/src/io/ciorch/git/WebhookParser.groovy
+++ b/src/io/ciorch/git/WebhookParser.groovy
@@ -1376,7 +1376,7 @@ class WebhookParser implements Serializable {
         }
 
         if (this.isClosedPR || this.isForcedPush || this.isNewBranch || this.isOpenedPR || EventType.SYNC == this.actionType || this.isPush) {
-            if (this.dstType in allowedList || allowedList.contains(this.dstType)) {
+            if (this.dstType in allowedList) {
                 result = true
             }
         }

--- a/tests/unit/groovy/CSharpAdapterTest.groovy
+++ b/tests/unit/groovy/CSharpAdapterTest.groovy
@@ -130,6 +130,32 @@ class CSharpAdapterTest extends Specification {
         result == false
     }
 
+    def "lint() uses lint_command override when provided"() {
+        given:
+        def capturedCmd = null
+        def system = mockSystem { String cmd -> capturedCmd = cmd; return 0 }
+        def adapter = new CSharpAdapter(null, system)
+
+        when:
+        boolean result = adapter.lint([lint_command: "dotnet format --severity warn"])
+
+        then:
+        result == true
+        capturedCmd == "dotnet format --severity warn"
+    }
+
+    def "lint() returns false when lint_command override fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new CSharpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([lint_command: "dotnet format --severity warn"])
+
+        then:
+        result == false
+    }
+
     def "test() happy path returns true"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/CSharpAdapterTest.groovy
+++ b/tests/unit/groovy/CSharpAdapterTest.groovy
@@ -1,0 +1,251 @@
+package io.ciorch.tests
+
+import io.ciorch.build.adapters.CSharpAdapter
+import io.ciorch.core.SystemCall
+import spock.lang.Specification
+
+class CSharpAdapterTest extends Specification {
+
+    def mockContext = [
+        echo: { msg -> },
+        withEnv: { List<String> vars, Closure body -> body.call() }
+    ]
+
+    private SystemCall mockSystem(int returnCode) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return returnCode }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return returnCode }
+        }
+    }
+
+    private SystemCall mockSystem(Closure<Integer> handler) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return handler(cmd) }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return handler(cmd) }
+        }
+    }
+
+    def "prepare() returns true when dotnet is found and restore succeeds"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CSharpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == true
+    }
+
+    def "prepare() returns false when dotnet is not found"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("dotnet --version") ? 1 : 0
+        }
+        def adapter = new CSharpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "prepare() returns false when dotnet restore fails"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("dotnet restore") ? 1 : 0
+        }
+        def adapter = new CSharpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "prepare() logs dotnet_version when provided in buildConfig"() {
+        given:
+        def system = mockSystem(0)
+        def messages = []
+        def ctx = [
+            echo: { msg -> messages << msg },
+            withEnv: { List<String> vars, Closure body -> body.call() }
+        ]
+        def adapter = new CSharpAdapter(ctx, system)
+
+        when:
+        adapter.prepare([dotnet_version: "8.0"], ctx)
+
+        then:
+        messages.any { it.contains("8.0") }
+    }
+
+    def "lint() happy path returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CSharpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+    }
+
+    def "lint() returns false when dotnet format --verify-no-changes fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new CSharpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == false
+    }
+
+    def "test() happy path returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CSharpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == true
+    }
+
+    def "test() returns false when dotnet test fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new CSharpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == false
+    }
+
+    def "test() uses custom test_command from buildConfig"() {
+        given:
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with testCmd directly
+        def adapter = new CSharpAdapter(null, system)
+
+        when:
+        boolean result = adapter.test([test_command: "dotnet test --filter Category=Unit"])
+
+        then:
+        result == true
+        capturedCmd == 'dotnet test --filter Category=Unit'
+    }
+
+    def "build() happy path returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CSharpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == true
+    }
+
+    def "build() returns false when dotnet publish fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new CSharpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+    }
+
+    def "build() uses custom build_command from buildConfig"() {
+        given:
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with buildCmd directly
+        def adapter = new CSharpAdapter(null, system)
+
+        when:
+        boolean result = adapter.build([build_command: "dotnet publish -c Release -r linux-x64 -o out/"])
+
+        then:
+        result == true
+        capturedCmd == 'dotnet publish -c Release -r linux-x64 -o out/'
+    }
+
+    def "getArtifacts() returns non-empty list after successful build"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CSharpAdapter(mockContext, system)
+        adapter.build([:])
+
+        when:
+        List<String> artifacts = adapter.getArtifacts()
+
+        then:
+        artifacts != null
+        !artifacts.isEmpty()
+        artifacts.contains("publish/")
+    }
+
+    def "getArtifacts() returns empty list before build"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CSharpAdapter(mockContext, system)
+
+        when:
+        List<String> artifacts = adapter.getArtifacts()
+
+        then:
+        artifacts.isEmpty()
+    }
+
+    def "getName() returns 'csharp'"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CSharpAdapter(mockContext, system)
+
+        when:
+        String name = adapter.getName()
+
+        then:
+        name == "csharp"
+    }
+}

--- a/tests/unit/groovy/CSharpAdapterTest.groovy
+++ b/tests/unit/groovy/CSharpAdapterTest.groovy
@@ -1,6 +1,7 @@
 package io.ciorch.tests
 
 import io.ciorch.build.adapters.CSharpAdapter
+import io.ciorch.core.Config
 import io.ciorch.core.SystemCall
 import spock.lang.Specification
 
@@ -81,6 +82,25 @@ class CSharpAdapterTest extends Specification {
 
         when:
         adapter.prepare([dotnet_version: "8.0"], ctx)
+
+        then:
+        messages.any { it.contains("8.0") }
+    }
+
+    def "prepare() logs dotnet_version from config.toolVersions when absent in buildConfig"() {
+        given:
+        def config = new Config()
+        config.toolVersions = [dotnet_version: "8.0"]
+        def system = mockSystem(0)
+        def messages = []
+        def ctx = [
+            echo: { msg -> messages << msg },
+            withEnv: { List<String> vars, Closure body -> body.call() }
+        ]
+        def adapter = new CSharpAdapter(ctx, system, config)
+
+        when:
+        adapter.prepare([:], ctx)
 
         then:
         messages.any { it.contains("8.0") }

--- a/tests/unit/groovy/CSharpAdapterTest.groovy
+++ b/tests/unit/groovy/CSharpAdapterTest.groovy
@@ -195,7 +195,6 @@ class CSharpAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with testCmd directly
         def adapter = new CSharpAdapter(null, system)
 
         when:
@@ -245,7 +244,6 @@ class CSharpAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with buildCmd directly
         def adapter = new CSharpAdapter(null, system)
 
         when:

--- a/tests/unit/groovy/CSharpAdapterTest.groovy
+++ b/tests/unit/groovy/CSharpAdapterTest.groovy
@@ -299,6 +299,21 @@ class CSharpAdapterTest extends Specification {
         artifacts.contains("publish/")
     }
 
+    def "build() clears stale artifacts when command fails after a successful build"() {
+        given:
+        def results = [0, 1]
+        def system = mockSystem { String cmd -> results.remove(0) }
+        def adapter = new CSharpAdapter(mockContext, system)
+        adapter.build([:])
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+        adapter.getArtifacts().isEmpty()
+    }
+
     def "getArtifacts() returns empty list before build"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/CSharpAdapterTest.groovy
+++ b/tests/unit/groovy/CSharpAdapterTest.groovy
@@ -252,6 +252,36 @@ class CSharpAdapterTest extends Specification {
         then:
         result == true
         capturedCmd == 'dotnet publish -c Release -r linux-x64 -o out/'
+        adapter.getArtifacts() == ["out/"]
+    }
+
+    def "build() uses explicit artifacts when custom build_command has no output path"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CSharpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([
+            build_command: "dotnet publish -c Release",
+            artifacts: ["custom-publish/"]
+        ])
+
+        then:
+        result == true
+        adapter.getArtifacts() == ["custom-publish/"]
+    }
+
+    def "build() leaves artifacts empty for custom build_command without output path or override"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CSharpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([build_command: "dotnet publish -c Release"])
+
+        then:
+        result == true
+        adapter.getArtifacts().isEmpty()
     }
 
     def "getArtifacts() returns non-empty list after successful build"() {

--- a/tests/unit/groovy/ConfigTest.groovy
+++ b/tests/unit/groovy/ConfigTest.groovy
@@ -175,6 +175,40 @@ class ConfigTest extends Specification {
         config.getVersion("php_version") == "8.3"
     }
 
+    def "buildMap preserves adapter-specific build keys"() {
+        given:
+        Config config = new Config(null)
+        config.loadMap([
+            build: [
+                adapter:         "java",
+                build_tool:      "gradle",
+                install_command: "make deps",
+                prepare_command: "make prepare",
+                artifacts:       ["dist/", "reports/"],
+                lint_command:    "make lint",
+                test_command:    "make test",
+                build_command:   "make package",
+                java_version:    "21",
+                docker:          [enabled: true]
+            ]
+        ])
+
+        when:
+        Map build = config.buildMap()
+
+        then:
+        build.build_tool == "gradle"
+        build.install_command == "make deps"
+        build.prepare_command == "make prepare"
+        build.artifacts == ["dist/", "reports/"]
+        build.lint_command == "make lint"
+        build.test_command == "make test"
+        build.build_command == "make package"
+        build.java_version == "21"
+        !build.containsKey("adapter")
+        !build.containsKey("docker")
+    }
+
     def "loadMap sets customMatrixPath from branching.custom_matrix"() {
         given:
         Config config = new Config(null)

--- a/tests/unit/groovy/ConfigTest.groovy
+++ b/tests/unit/groovy/ConfigTest.groovy
@@ -13,12 +13,12 @@ class ConfigTest extends Specification {
         config.buildAdapter == ""
     }
 
-    def "default branchingStrategy is gitflow"() {
+    def "default branchingStrategy is default-gitflow"() {
         when:
         Config config = new Config(null)
 
         then:
-        config.branchingStrategy == "gitflow"
+        config.branchingStrategy == "default-gitflow"
     }
 
     def "loadMap sets buildAdapter and deployAdapter"() {

--- a/tests/unit/groovy/ConfigTest.groovy
+++ b/tests/unit/groovy/ConfigTest.groovy
@@ -189,7 +189,13 @@ class ConfigTest extends Specification {
                 test_command:    "make test",
                 build_command:   "make package",
                 java_version:    "21",
-                docker:          [enabled: true]
+                docker:          [
+                    enabled: true,
+                    tag: "v1",
+                    dockerfile: "deploy/Dockerfile",
+                    context: ".",
+                    build_args: [APP_ENV: "prod"]
+                ]
             ]
         ])
 
@@ -205,6 +211,11 @@ class ConfigTest extends Specification {
         build.test_command == "make test"
         build.build_command == "make package"
         build.java_version == "21"
+        build.enabled == true
+        build.tag == "v1"
+        build.dockerfile == "deploy/Dockerfile"
+        build.context == "."
+        build.build_args == [APP_ENV: "prod"]
         !build.containsKey("adapter")
         !build.containsKey("docker")
     }

--- a/tests/unit/groovy/CppAdapterTest.groovy
+++ b/tests/unit/groovy/CppAdapterTest.groovy
@@ -258,11 +258,11 @@ class CppAdapterTest extends Specification {
         def adapter = new CppAdapter(null, system)
 
         when:
-        boolean result = adapter.build([build_command: "cmake --build build --config Release -j 8"])
+        boolean result = adapter.build([build_command: "cmake --build build --config Release --parallel 8"])
 
         then:
         result == true
-        capturedCmd == "cmake --build build --config Release -j 8"
+        capturedCmd == "cmake --build build --config Release --parallel 8"
     }
 
     def "getArtifacts() returns empty list before build"() {

--- a/tests/unit/groovy/CppAdapterTest.groovy
+++ b/tests/unit/groovy/CppAdapterTest.groovy
@@ -1,0 +1,291 @@
+package io.ciorch.tests
+
+import io.ciorch.build.adapters.CppAdapter
+import io.ciorch.core.SystemCall
+import spock.lang.Specification
+
+class CppAdapterTest extends Specification {
+
+    def mockContext = [
+        echo: { msg -> },
+        withEnv: { List<String> vars, Closure body -> body.call() }
+    ]
+
+    private SystemCall mockSystem(int returnCode) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return returnCode }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return returnCode }
+        }
+    }
+
+    private SystemCall mockSystem(Closure<Integer> handler) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return handler(cmd) }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return handler(cmd) }
+        }
+    }
+
+    def "prepare() returns true when cmake and ninja are found"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CppAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == true
+    }
+
+    def "prepare() returns true when cmake and make are found (no ninja)"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("ninja --version")) return 1
+            return 0
+        }
+        def adapter = new CppAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == true
+    }
+
+    def "prepare() returns false when cmake is not found"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("cmake --version") ? 1 : 0
+        }
+        def adapter = new CppAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "prepare() returns false when neither ninja nor make found"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("cmake --version")) return 0
+            return 1
+        }
+        def adapter = new CppAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "lint() cppcheck passes returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CppAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+    }
+
+    def "lint() cppcheck fails returns false"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("which cppcheck")) return 0
+            if (cmd.contains("cppcheck")) return 1
+            return 0
+        }
+        def adapter = new CppAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == false
+    }
+
+    def "lint() skips non-fatally when cppcheck is absent"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("which cppcheck") ? 1 : 0
+        }
+        def adapter = new CppAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+    }
+
+    def "lint() uses custom lint_command from buildConfig"() {
+        given:
+        def capturedCmd = null
+        def system = mockSystem { String cmd ->
+            capturedCmd = cmd
+            return 0
+        }
+        // null context so withEnv is skipped and the fallback fires with lintCmd directly
+        def adapter = new CppAdapter(null, system)
+
+        when:
+        boolean result = adapter.lint([lint_command: "clang-tidy src/*.cpp"])
+
+        then:
+        result == true
+        capturedCmd == "clang-tidy src/*.cpp"
+    }
+
+    def "test() happy path returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CppAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == true
+    }
+
+    def "test() returns false when ctest fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new CppAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == false
+    }
+
+    def "test() uses custom test_command from buildConfig"() {
+        given:
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with testCmd directly
+        def adapter = new CppAdapter(null, system)
+
+        when:
+        boolean result = adapter.test([test_command: "ctest --test-dir build -V"])
+
+        then:
+        result == true
+        capturedCmd == "ctest --test-dir build -V"
+    }
+
+    def "build() returns true with artifact build/ on success"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CppAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == true
+        adapter.getArtifacts() == ["build/"]
+    }
+
+    def "build() returns false when cmake configure fails"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("cmake -B build") ? 1 : 0
+        }
+        def adapter = new CppAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+    }
+
+    def "build() returns false when build command fails"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("cmake -B build")) return 0
+            return 1
+        }
+        def adapter = new CppAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+    }
+
+    def "build() uses custom build_command from buildConfig"() {
+        given:
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                if (cmd.contains("cmake -B build")) return 0
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                if (cmd.contains("cmake -B build")) return 0
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with buildCmd directly
+        def adapter = new CppAdapter(null, system)
+
+        when:
+        boolean result = adapter.build([build_command: "cmake --build build --config Release -j 8"])
+
+        then:
+        result == true
+        capturedCmd == "cmake --build build --config Release -j 8"
+    }
+
+    def "getArtifacts() returns empty list before build"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CppAdapter(mockContext, system)
+
+        when:
+        List<String> artifacts = adapter.getArtifacts()
+
+        then:
+        artifacts.isEmpty()
+    }
+
+    def "getName() returns 'cpp'"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CppAdapter(mockContext, system)
+
+        when:
+        String name = adapter.getName()
+
+        then:
+        name == "cpp"
+    }
+}

--- a/tests/unit/groovy/CppAdapterTest.groovy
+++ b/tests/unit/groovy/CppAdapterTest.groovy
@@ -262,6 +262,24 @@ class CppAdapterTest extends Specification {
         capturedCmd == "cmake --build build --config Release --parallel 8"
     }
 
+    def "build() clears stale artifacts when build command fails after a successful build"() {
+        given:
+        def buildResults = [0, 1]
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("cmake -B build")) return 0
+            return buildResults.remove(0)
+        }
+        def adapter = new CppAdapter(mockContext, system)
+        adapter.build([:])
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+        adapter.getArtifacts().isEmpty()
+    }
+
     def "getArtifacts() returns empty list before build"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/CppAdapterTest.groovy
+++ b/tests/unit/groovy/CppAdapterTest.groovy
@@ -238,16 +238,23 @@ class CppAdapterTest extends Specification {
     def "build() uses custom build_command from buildConfig"() {
         given:
         def capturedCmd = null
+        def configureRan = false
         def system = new SystemCall(null, "", "", "", "") {
             @Override
             def run_command(String cmd, int mode) {
-                if (cmd.contains("cmake -B build")) return 0
+                if (cmd.contains("cmake -B build")) {
+                    configureRan = true
+                    return 0
+                }
                 capturedCmd = cmd
                 return 0
             }
             @Override
             def run_command(String cmd, int mode, int timeout) {
-                if (cmd.contains("cmake -B build")) return 0
+                if (cmd.contains("cmake -B build")) {
+                    configureRan = true
+                    return 0
+                }
                 capturedCmd = cmd
                 return 0
             }
@@ -260,6 +267,24 @@ class CppAdapterTest extends Specification {
         then:
         result == true
         capturedCmd == "cmake --build build --config Release --parallel 8"
+        configureRan == false
+        adapter.getArtifacts().isEmpty()
+    }
+
+    def "build() uses explicit artifacts for custom build_command"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new CppAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([
+            build_command: "ninja -C out",
+            artifacts: ["out/"]
+        ])
+
+        then:
+        result == true
+        adapter.getArtifacts() == ["out/"]
     }
 
     def "build() clears stale artifacts when build command fails after a successful build"() {

--- a/tests/unit/groovy/CppAdapterTest.groovy
+++ b/tests/unit/groovy/CppAdapterTest.groovy
@@ -134,7 +134,6 @@ class CppAdapterTest extends Specification {
             capturedCmd = cmd
             return 0
         }
-        // null context so withEnv is skipped and the fallback fires with lintCmd directly
         def adapter = new CppAdapter(null, system)
 
         when:
@@ -184,7 +183,6 @@ class CppAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with testCmd directly
         def adapter = new CppAdapter(null, system)
 
         when:
@@ -254,7 +252,6 @@ class CppAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with buildCmd directly
         def adapter = new CppAdapter(null, system)
 
         when:

--- a/tests/unit/groovy/GenericAdapterTest.groovy
+++ b/tests/unit/groovy/GenericAdapterTest.groovy
@@ -196,6 +196,19 @@ class GenericAdapterTest extends Specification {
         adapter.getArtifacts() == ["dist/", "bin/"]
     }
 
+    def "build() normalizes single-string artifact to one-element list"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GenericAdapter(null, system)
+
+        when:
+        boolean result = adapter.build([build_command: "make all", artifacts: "dist/"])
+
+        then:
+        result == true
+        adapter.getArtifacts() == ["dist/"]
+    }
+
     def "build() returns false when build_command fails"() {
         given:
         def system = mockSystem(1)

--- a/tests/unit/groovy/GenericAdapterTest.groovy
+++ b/tests/unit/groovy/GenericAdapterTest.groovy
@@ -1,0 +1,247 @@
+package io.ciorch.tests
+
+import io.ciorch.build.adapters.GenericAdapter
+import io.ciorch.core.SystemCall
+import spock.lang.Specification
+
+class GenericAdapterTest extends Specification {
+
+    def mockContext = [
+        echo: { msg -> },
+        withEnv: { List<String> vars, Closure body -> body.call() }
+    ]
+
+    private SystemCall mockSystem(int returnCode) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return returnCode }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return returnCode }
+        }
+    }
+
+    private SystemCall mockSystem(Closure<Integer> handler) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return handler(cmd) }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return handler(cmd) }
+        }
+    }
+
+    def "prepare() runs install_command when provided and returns result"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GenericAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([install_command: "apt-get install -y libfoo"], mockContext)
+
+        then:
+        result == true
+    }
+
+    def "prepare() returns false when install_command fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new GenericAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([install_command: "apt-get install -y libfoo"], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "prepare() skips and returns true when no install_command configured"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GenericAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == true
+    }
+
+    def "prepare() runs prepare_command when provided"() {
+        given:
+        def capturedCmd = null
+        def system = mockSystem { String cmd ->
+            capturedCmd = cmd
+            return 0
+        }
+        // null context so withEnv is skipped
+        def adapter = new GenericAdapter(null, system)
+
+        when:
+        boolean result = adapter.prepare([prepare_command: "make deps"], null)
+
+        then:
+        result == true
+        capturedCmd == "make deps"
+    }
+
+    def "lint() runs lint_command when provided and returns true on success"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GenericAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([lint_command: "my-linter ."])
+
+        then:
+        result == true
+    }
+
+    def "lint() returns false when lint_command fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new GenericAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([lint_command: "my-linter ."])
+
+        then:
+        result == false
+    }
+
+    def "lint() skips and returns true when no lint_command configured"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GenericAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+    }
+
+    def "test() runs test_command and captures exact command"() {
+        given:
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with testCmd directly
+        def adapter = new GenericAdapter(null, system)
+
+        when:
+        boolean result = adapter.test([test_command: "make test"])
+
+        then:
+        result == true
+        capturedCmd == "make test"
+    }
+
+    def "test() returns false when test_command fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new GenericAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([test_command: "make test"])
+
+        then:
+        result == false
+    }
+
+    def "test() skips and returns true when no test_command configured"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GenericAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == true
+    }
+
+    def "build() runs build_command, captures exact command, and uses artifacts from config"() {
+        given:
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with buildCmd directly
+        def adapter = new GenericAdapter(null, system)
+
+        when:
+        boolean result = adapter.build([build_command: "make all", artifacts: ["dist/", "bin/"]])
+
+        then:
+        result == true
+        capturedCmd == "make all"
+        adapter.getArtifacts() == ["dist/", "bin/"]
+    }
+
+    def "build() returns false when build_command fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new GenericAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([build_command: "make all"])
+
+        then:
+        result == false
+    }
+
+    def "build() skips and returns true with empty artifacts when no build_command configured"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GenericAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == true
+        adapter.getArtifacts().isEmpty()
+    }
+
+    def "getArtifacts() returns empty list before build"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GenericAdapter(mockContext, system)
+
+        when:
+        List<String> artifacts = adapter.getArtifacts()
+
+        then:
+        artifacts.isEmpty()
+    }
+
+    def "getName() returns 'generic'"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GenericAdapter(mockContext, system)
+
+        when:
+        String name = adapter.getName()
+
+        then:
+        name == "generic"
+    }
+}

--- a/tests/unit/groovy/GenericAdapterTest.groovy
+++ b/tests/unit/groovy/GenericAdapterTest.groovy
@@ -82,6 +82,46 @@ class GenericAdapterTest extends Specification {
         capturedCmd == "make deps"
     }
 
+    def "prepare() runs install_command before prepare_command when both are provided"() {
+        given:
+        def commands = []
+        def system = mockSystem { String cmd ->
+            commands << cmd
+            return 0
+        }
+        def adapter = new GenericAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([
+            install_command: "make install-deps",
+            prepare_command: "make prepare"
+        ], mockContext)
+
+        then:
+        result == true
+        commands == ["make install-deps", "make prepare"]
+    }
+
+    def "prepare() stops when install_command fails before prepare_command"() {
+        given:
+        def commands = []
+        def system = mockSystem { String cmd ->
+            commands << cmd
+            return cmd == "make install-deps" ? 1 : 0
+        }
+        def adapter = new GenericAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([
+            install_command: "make install-deps",
+            prepare_command: "make prepare"
+        ], mockContext)
+
+        then:
+        result == false
+        commands == ["make install-deps"]
+    }
+
     def "lint() runs lint_command when provided and returns true on success"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/GenericAdapterTest.groovy
+++ b/tests/unit/groovy/GenericAdapterTest.groovy
@@ -218,6 +218,21 @@ class GenericAdapterTest extends Specification {
         result == false
     }
 
+    def "build() clears stale artifacts when build_command fails after a successful build"() {
+        given:
+        def results = [0, 1]
+        def system = mockSystem { String cmd -> results.remove(0) }
+        def adapter = new GenericAdapter(mockContext, system)
+        adapter.build([build_command: "make all", artifacts: ["dist/"]])
+
+        when:
+        boolean result = adapter.build([build_command: "make all", artifacts: ["dist/"]])
+
+        then:
+        result == false
+        adapter.getArtifacts().isEmpty()
+    }
+
     def "build() skips and returns true with empty artifacts when no build_command configured"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/GenericAdapterTest.groovy
+++ b/tests/unit/groovy/GenericAdapterTest.groovy
@@ -72,7 +72,6 @@ class GenericAdapterTest extends Specification {
             capturedCmd = cmd
             return 0
         }
-        // null context so withEnv is skipped
         def adapter = new GenericAdapter(null, system)
 
         when:
@@ -134,7 +133,6 @@ class GenericAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with testCmd directly
         def adapter = new GenericAdapter(null, system)
 
         when:
@@ -184,7 +182,6 @@ class GenericAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with buildCmd directly
         def adapter = new GenericAdapter(null, system)
 
         when:

--- a/tests/unit/groovy/GoAdapterTest.groovy
+++ b/tests/unit/groovy/GoAdapterTest.groovy
@@ -132,6 +132,32 @@ class GoAdapterTest extends Specification {
         executedCommands.any { it.contains("golangci-lint") }
     }
 
+    def "lint() uses lint_command override when provided"() {
+        given:
+        def capturedCmd = null
+        def system = mockSystem { String cmd -> capturedCmd = cmd; return 0 }
+        def adapter = new GoAdapter(null, system)
+
+        when:
+        boolean result = adapter.lint([lint_command: "custom-go-lint ./..."])
+
+        then:
+        result == true
+        capturedCmd == "custom-go-lint ./..."
+    }
+
+    def "lint() returns false when lint_command override fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new GoAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([lint_command: "custom-go-lint ./..."])
+
+        then:
+        result == false
+    }
+
     def "lint() returns false when go vet fails"() {
         given:
         def system = mockSystem { String cmd ->
@@ -246,7 +272,7 @@ class GoAdapterTest extends Specification {
         capturedCmd == 'go build -o bin/app .'
     }
 
-    def "getArtifacts() returns non-empty list after successful build"() {
+    def "getArtifacts() returns empty list after successful build"() {
         given:
         def system = mockSystem(0)
         def adapter = new GoAdapter(mockContext, system)
@@ -257,8 +283,7 @@ class GoAdapterTest extends Specification {
 
         then:
         artifacts != null
-        !artifacts.isEmpty()
-        artifacts.contains("./...")
+        artifacts.isEmpty()
     }
 
     def "getArtifacts() returns empty list before build"() {

--- a/tests/unit/groovy/GoAdapterTest.groovy
+++ b/tests/unit/groovy/GoAdapterTest.groovy
@@ -1,6 +1,7 @@
 package io.ciorch.tests
 
 import io.ciorch.build.adapters.GoAdapter
+import io.ciorch.core.Config
 import io.ciorch.core.SystemCall
 import spock.lang.Specification
 
@@ -67,6 +68,25 @@ class GoAdapterTest extends Specification {
 
         when:
         adapter.prepare([go_version: "1.22"], ctx)
+
+        then:
+        messages.any { it.contains("1.22") }
+    }
+
+    def "prepare() logs go_version from config.toolVersions when absent in buildConfig"() {
+        given:
+        def config = new Config()
+        config.toolVersions = [go_version: "1.22"]
+        def system = mockSystem(0)
+        def messages = []
+        def ctx = [
+            echo: { msg -> messages << msg },
+            withEnv: { List<String> vars, Closure body -> body.call() }
+        ]
+        def adapter = new GoAdapter(ctx, system, config)
+
+        when:
+        adapter.prepare([:], ctx)
 
         then:
         messages.any { it.contains("1.22") }

--- a/tests/unit/groovy/GoAdapterTest.groovy
+++ b/tests/unit/groovy/GoAdapterTest.groovy
@@ -152,14 +152,28 @@ class GoAdapterTest extends Specification {
 
     def "test() uses custom test_command from buildConfig"() {
         given:
-        def system = mockSystem(0)
-        def adapter = new GoAdapter(mockContext, system)
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with testCmd directly
+        def adapter = new GoAdapter(null, system)
 
         when:
         boolean result = adapter.test([test_command: "go test -v ./..."])
 
         then:
         result == true
+        capturedCmd == 'go test -v ./...'
     }
 
     def "build() happy path returns true"() {
@@ -188,14 +202,28 @@ class GoAdapterTest extends Specification {
 
     def "build() uses custom build_command from buildConfig"() {
         given:
-        def system = mockSystem(0)
-        def adapter = new GoAdapter(mockContext, system)
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with buildCmd directly
+        def adapter = new GoAdapter(null, system)
 
         when:
         boolean result = adapter.build([build_command: "go build -o bin/app ."])
 
         then:
         result == true
+        capturedCmd == 'go build -o bin/app .'
     }
 
     def "getArtifacts() returns non-empty list after successful build"() {

--- a/tests/unit/groovy/GoAdapterTest.groovy
+++ b/tests/unit/groovy/GoAdapterTest.groovy
@@ -1,0 +1,239 @@
+package io.ciorch.tests
+
+import io.ciorch.build.adapters.GoAdapter
+import io.ciorch.core.SystemCall
+import spock.lang.Specification
+
+class GoAdapterTest extends Specification {
+
+    def mockContext = [
+        echo: { msg -> },
+        withEnv: { List<String> vars, Closure body -> body.call() }
+    ]
+
+    private SystemCall mockSystem(int returnCode) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return returnCode }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return returnCode }
+        }
+    }
+
+    private SystemCall mockSystem(Closure<Integer> handler) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return handler(cmd) }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return handler(cmd) }
+        }
+    }
+
+    def "prepare() returns true when go is found"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GoAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == true
+    }
+
+    def "prepare() returns false when go is not found"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.startsWith("go version") ? 1 : 0
+        }
+        def adapter = new GoAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "prepare() logs go_version informational message when provided"() {
+        given:
+        def system = mockSystem(0)
+        def messages = []
+        def ctx = [
+            echo: { msg -> messages << msg },
+            withEnv: { List<String> vars, Closure body -> body.call() }
+        ]
+        def adapter = new GoAdapter(ctx, system)
+
+        when:
+        adapter.prepare([go_version: "1.22"], ctx)
+
+        then:
+        messages.any { it.contains("1.22") }
+    }
+
+    def "lint() happy path returns true"() {
+        given:
+        // 0 for go vet, 1 for which golangci-lint (not found => skip)
+        def system = mockSystem { String cmd ->
+            cmd.contains("which golangci-lint") ? 1 : 0
+        }
+        def adapter = new GoAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+    }
+
+    def "lint() runs golangci-lint when available"() {
+        given:
+        def executedCommands = []
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                executedCommands << cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                executedCommands << cmd
+                return 0
+            }
+        }
+        def adapter = new GoAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+        executedCommands.any { it.contains("golangci-lint") }
+    }
+
+    def "lint() returns false when go vet fails"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("go vet") ? 1 : 0
+        }
+        def adapter = new GoAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == false
+    }
+
+    def "test() happy path returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GoAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == true
+    }
+
+    def "test() returns false when go test fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new GoAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == false
+    }
+
+    def "test() uses custom test_command from buildConfig"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GoAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([test_command: "go test -v ./..."])
+
+        then:
+        result == true
+    }
+
+    def "build() happy path returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GoAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == true
+    }
+
+    def "build() returns false when go build fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new GoAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+    }
+
+    def "build() uses custom build_command from buildConfig"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GoAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([build_command: "go build -o bin/app ."])
+
+        then:
+        result == true
+    }
+
+    def "getArtifacts() returns non-empty list after successful build"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GoAdapter(mockContext, system)
+        adapter.build([:])
+
+        when:
+        List<String> artifacts = adapter.getArtifacts()
+
+        then:
+        artifacts != null
+        !artifacts.isEmpty()
+        artifacts.contains("./...")
+    }
+
+    def "getArtifacts() returns empty list before build"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GoAdapter(mockContext, system)
+
+        when:
+        List<String> artifacts = adapter.getArtifacts()
+
+        then:
+        artifacts.isEmpty()
+    }
+
+    def "getName() returns 'go'"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new GoAdapter(mockContext, system)
+
+        when:
+        String name = adapter.getName()
+
+        then:
+        name == "go"
+    }
+}

--- a/tests/unit/groovy/GoAdapterTest.groovy
+++ b/tests/unit/groovy/GoAdapterTest.groovy
@@ -211,7 +211,6 @@ class GoAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with testCmd directly
         def adapter = new GoAdapter(null, system)
 
         when:
@@ -261,7 +260,6 @@ class GoAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with buildCmd directly
         def adapter = new GoAdapter(null, system)
 
         when:

--- a/tests/unit/groovy/GoAdapterTest.groovy
+++ b/tests/unit/groovy/GoAdapterTest.groovy
@@ -296,6 +296,22 @@ class GoAdapterTest extends Specification {
         artifacts.isEmpty()
     }
 
+    def "build() clears stale artifacts before a failed build"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new GoAdapter(mockContext, system)
+        def field = GoAdapter.class.getDeclaredField("artifacts")
+        field.accessible = true
+        field.set(adapter, ["bin/app"])
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+        adapter.getArtifacts().isEmpty()
+    }
+
     def "getName() returns 'go'"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/JavaAdapterTest.groovy
+++ b/tests/unit/groovy/JavaAdapterTest.groovy
@@ -1,6 +1,7 @@
 package io.ciorch.tests
 
 import io.ciorch.build.adapters.JavaAdapter
+import io.ciorch.core.Config
 import io.ciorch.core.SystemCall
 import spock.lang.Specification
 
@@ -113,6 +114,40 @@ class JavaAdapterTest extends Specification {
 
         then:
         messages.any { it.contains("17") }
+    }
+
+    def "prepare() logs java_version from config.toolVersions when absent in buildConfig"() {
+        given:
+        def config = new Config()
+        config.toolVersions = [java_version: "21"]
+        def system = mockSystem(0)
+        def messages = []
+        def ctx = [
+            echo: { msg -> messages << msg },
+            withEnv: { List<String> vars, Closure body -> body.call() }
+        ]
+        def adapter = new JavaAdapter(ctx, system, config)
+
+        when:
+        adapter.prepare([build_tool: "maven"], ctx)
+
+        then:
+        messages.any { it.contains("21") }
+    }
+
+    def "prepare() reads build_tool from config.raw when absent in buildConfig"() {
+        given:
+        def config = new Config()
+        config.raw = [ciorch: [build: [build_tool: "gradle"]]]
+        def system = mockSystem(0)
+        def adapter = new JavaAdapter(mockContext, system, config)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == true
+        adapter.buildTool == "gradle"
     }
 
     def "lint() happy path returns true (maven)"() {

--- a/tests/unit/groovy/JavaAdapterTest.groovy
+++ b/tests/unit/groovy/JavaAdapterTest.groovy
@@ -85,10 +85,12 @@ class JavaAdapterTest extends Specification {
         adapter.buildTool == "gradle"
     }
 
-    def "prepare() returns false when gradle not found for gradle project"() {
+    def "prepare() returns false when neither gradlew nor gradle found"() {
         given:
         def system = mockSystem { String cmd ->
-            cmd.contains("gradle --version") ? 1 : 0
+            if (cmd.contains("test -f gradlew")) return 1      // no wrapper
+            if (cmd.contains("gradle --version")) return 1     // no system gradle
+            return 0
         }
         def adapter = new JavaAdapter(mockContext, system)
 
@@ -97,6 +99,69 @@ class JavaAdapterTest extends Specification {
 
         then:
         result == false
+    }
+
+    def "prepare() uses Gradle wrapper when gradlew is present"() {
+        given:
+        def system = mockSystem(0)  // all succeed: wrapper found, chmod succeeds
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([build_tool: "gradle"], mockContext)
+
+        then:
+        result == true
+        adapter.gradleCmd == "./gradlew"
+    }
+
+    def "prepare() falls back to system gradle when wrapper absent"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("test -f gradlew")) return 1  // no wrapper
+            return 0                                         // system gradle present
+        }
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([build_tool: "gradle"], mockContext)
+
+        then:
+        result == true
+        adapter.gradleCmd == "gradle"
+    }
+
+    def "prepare() detects gradle via build.gradle file on agent"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("test -f build.gradle")) return 0  // build.gradle present
+            return 0
+        }
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == true
+        adapter.buildTool == "gradle"
+    }
+
+    def "prepare() defaults to maven when no gradle files found"() {
+        given:
+        def system = mockSystem { String cmd ->
+            // no gradle files, all else succeeds
+            if (cmd.contains("test -f build.gradle")) return 1
+            if (cmd.contains("test -f build.gradle.kts")) return 1
+            return 0
+        }
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == true
+        adapter.buildTool == "maven"
     }
 
     def "prepare() logs java_version when provided in buildConfig"() {

--- a/tests/unit/groovy/JavaAdapterTest.groovy
+++ b/tests/unit/groovy/JavaAdapterTest.groovy
@@ -1,0 +1,326 @@
+package io.ciorch.tests
+
+import io.ciorch.build.adapters.JavaAdapter
+import io.ciorch.core.SystemCall
+import spock.lang.Specification
+
+class JavaAdapterTest extends Specification {
+
+    def mockContext = [
+        echo: { msg -> },
+        withEnv: { List<String> vars, Closure body -> body.call() }
+    ]
+
+    private SystemCall mockSystem(int returnCode) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return returnCode }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return returnCode }
+        }
+    }
+
+    private SystemCall mockSystem(Closure<Integer> handler) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return handler(cmd) }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return handler(cmd) }
+        }
+    }
+
+    def "prepare() returns true for maven project when java and mvn are found"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        // force maven mode to avoid file-based detection picking up build.gradle in cwd
+        boolean result = adapter.prepare([build_tool: "maven"], mockContext)
+
+        then:
+        result == true
+    }
+
+    def "prepare() returns false when java is not found"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("java -version") ? 1 : 0
+        }
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "prepare() returns false when mvn is not found"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("mvn --version") ? 1 : 0
+        }
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        // force maven mode to avoid file-based detection picking up build.gradle in cwd
+        boolean result = adapter.prepare([build_tool: "maven"], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "prepare() detects gradle when build_tool config key is 'gradle'"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([build_tool: "gradle"], mockContext)
+
+        then:
+        result == true
+        adapter.buildTool == "gradle"
+    }
+
+    def "prepare() returns false when gradle not found for gradle project"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("gradle --version") ? 1 : 0
+        }
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([build_tool: "gradle"], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "prepare() logs java_version when provided in buildConfig"() {
+        given:
+        def system = mockSystem(0)
+        def messages = []
+        def ctx = [
+            echo: { msg -> messages << msg },
+            withEnv: { List<String> vars, Closure body -> body.call() }
+        ]
+        def adapter = new JavaAdapter(ctx, system)
+
+        when:
+        adapter.prepare([java_version: "17"], ctx)
+
+        then:
+        messages.any { it.contains("17") }
+    }
+
+    def "lint() happy path returns true (maven)"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+    }
+
+    def "lint() returns false when checkstyle fails (maven)"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == false
+    }
+
+    def "lint() happy path returns true (gradle)"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new JavaAdapter(mockContext, system)
+        adapter.buildTool = "gradle"
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+    }
+
+    def "lint() returns false when gradle check fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new JavaAdapter(mockContext, system)
+        adapter.buildTool = "gradle"
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == false
+    }
+
+    def "lint() uses custom lint_command from buildConfig"() {
+        given:
+        def capturedCmd = null
+        def system = mockSystem { String cmd ->
+            capturedCmd = cmd
+            return 0
+        }
+        // null context so withEnv is skipped and the fallback fires with lintCmd directly
+        def adapter = new JavaAdapter(null, system)
+
+        when:
+        boolean result = adapter.lint([lint_command: "my-custom-lint"])
+
+        then:
+        result == true
+        capturedCmd == "my-custom-lint"
+    }
+
+    def "test() happy path returns true (maven)"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == true
+    }
+
+    def "test() returns false when mvn test fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == false
+    }
+
+    def "test() uses custom test_command from buildConfig"() {
+        given:
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with testCmd directly
+        def adapter = new JavaAdapter(null, system)
+
+        when:
+        boolean result = adapter.test([test_command: "mvn test -Dgroups=unit"])
+
+        then:
+        result == true
+        capturedCmd == "mvn test -Dgroups=unit"
+    }
+
+    def "build() returns maven artifact path on success"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new JavaAdapter(mockContext, system)
+        // explicitly set maven so the test is not influenced by file-based detection
+        adapter.buildTool = "maven"
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == true
+        adapter.getArtifacts() == ["target/"]
+    }
+
+    def "build() returns gradle artifact path on success"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new JavaAdapter(mockContext, system)
+        adapter.buildTool = "gradle"
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == true
+        adapter.getArtifacts() == ["build/libs/"]
+    }
+
+    def "build() returns false when build command fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+    }
+
+    def "build() uses custom build_command from buildConfig"() {
+        given:
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with buildCmd directly
+        def adapter = new JavaAdapter(null, system)
+
+        when:
+        boolean result = adapter.build([build_command: "mvn package -P production"])
+
+        then:
+        result == true
+        capturedCmd == "mvn package -P production"
+    }
+
+    def "getArtifacts() returns empty list before build"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        List<String> artifacts = adapter.getArtifacts()
+
+        then:
+        artifacts.isEmpty()
+    }
+
+    def "getName() returns 'java'"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        String name = adapter.getName()
+
+        then:
+        name == "java"
+    }
+}

--- a/tests/unit/groovy/JavaAdapterTest.groovy
+++ b/tests/unit/groovy/JavaAdapterTest.groovy
@@ -114,6 +114,38 @@ class JavaAdapterTest extends Specification {
         adapter.gradleCmd == "./gradlew"
     }
 
+    def "prepare() falls back to system gradle when chmod +x gradlew fails"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("chmod +x gradlew")) return 1  // chmod fails
+            return 0                                          // system gradle present
+        }
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([build_tool: "gradle"], mockContext)
+
+        then:
+        result == true
+        adapter.gradleCmd == "gradle"
+    }
+
+    def "prepare() returns false when chmod fails and gradle not in PATH"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("chmod +x gradlew")) return 1
+            if (cmd.contains("gradle --version")) return 1
+            return 0
+        }
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([build_tool: "gradle"], mockContext)
+
+        then:
+        result == false
+    }
+
     def "prepare() falls back to system gradle when wrapper absent"() {
         given:
         def system = mockSystem { String cmd ->

--- a/tests/unit/groovy/JavaAdapterTest.groovy
+++ b/tests/unit/groovy/JavaAdapterTest.groovy
@@ -271,9 +271,13 @@ class JavaAdapterTest extends Specification {
         result == false
     }
 
-    def "lint() happy path returns true (gradle)"() {
+    def "lint() runs checkstyle tasks for gradle"() {
         given:
-        def system = mockSystem(0)
+        def capturedCmd = null
+        def system = mockSystem { String cmd ->
+            capturedCmd = cmd
+            return 0
+        }
         def adapter = new JavaAdapter(mockContext, system)
         adapter.buildTool = "gradle"
 
@@ -282,6 +286,7 @@ class JavaAdapterTest extends Specification {
 
         then:
         result == true
+        capturedCmd == "./gradlew checkstyleMain checkstyleTest -q"
     }
 
     def "lint() returns false when gradle check fails"() {

--- a/tests/unit/groovy/JavaAdapterTest.groovy
+++ b/tests/unit/groovy/JavaAdapterTest.groovy
@@ -304,7 +304,6 @@ class JavaAdapterTest extends Specification {
             capturedCmd = cmd
             return 0
         }
-        // null context so withEnv is skipped and the fallback fires with lintCmd directly
         def adapter = new JavaAdapter(null, system)
 
         when:
@@ -354,7 +353,6 @@ class JavaAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with testCmd directly
         def adapter = new JavaAdapter(null, system)
 
         when:
@@ -421,7 +419,6 @@ class JavaAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with buildCmd directly
         def adapter = new JavaAdapter(null, system)
 
         when:

--- a/tests/unit/groovy/JavaAdapterTest.groovy
+++ b/tests/unit/groovy/JavaAdapterTest.groovy
@@ -429,6 +429,22 @@ class JavaAdapterTest extends Specification {
         capturedCmd == "mvn package -P production"
     }
 
+    def "build() clears stale artifacts when command fails after a successful build"() {
+        given:
+        def results = [0, 1]
+        def system = mockSystem { String cmd -> results.remove(0) }
+        def adapter = new JavaAdapter(mockContext, system)
+        adapter.buildTool = "maven"
+        adapter.build([:])
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+        adapter.getArtifacts().isEmpty()
+    }
+
     def "getArtifacts() returns empty list before build"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/JavaAdapterTest.groovy
+++ b/tests/unit/groovy/JavaAdapterTest.groovy
@@ -427,6 +427,23 @@ class JavaAdapterTest extends Specification {
         then:
         result == true
         capturedCmd == "mvn package -P production"
+        adapter.getArtifacts().isEmpty()
+    }
+
+    def "build() uses explicit artifacts for custom build_command"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new JavaAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([
+            build_command: "mvn package -P production",
+            artifacts: ["custom-target/"]
+        ])
+
+        then:
+        result == true
+        adapter.getArtifacts() == ["custom-target/"]
     }
 
     def "build() clears stale artifacts when command fails after a successful build"() {

--- a/tests/unit/groovy/NodeAdapterTest.groovy
+++ b/tests/unit/groovy/NodeAdapterTest.groovy
@@ -110,6 +110,24 @@ class NodeAdapterTest extends Specification {
         result == true
     }
 
+    def "lint() uses custom lintCommand from buildConfig"() {
+        given:
+        def capturedCmd = null
+        def system = mockSystem { String cmd ->
+            capturedCmd = cmd
+            return 0
+        }
+        // null context so withEnv is skipped and the fallback fires with lintCmd directly
+        def adapter = new NodeAdapter(null, system)
+
+        when:
+        boolean result = adapter.lint([lintCommand: 'my-custom-lint'])
+
+        then:
+        result == true
+        capturedCmd == 'my-custom-lint'
+    }
+
     def "test() happy path returns true"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/NodeAdapterTest.groovy
+++ b/tests/unit/groovy/NodeAdapterTest.groovy
@@ -1,0 +1,236 @@
+package io.ciorch.tests
+
+import io.ciorch.build.adapters.NodeAdapter
+import io.ciorch.core.SystemCall
+import spock.lang.Specification
+
+class NodeAdapterTest extends Specification {
+
+    def mockContext = [
+        echo: { msg -> },
+        withEnv: { List<String> vars, Closure body -> body.call() }
+    ]
+
+    private SystemCall mockSystem(int returnCode) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return returnCode }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return returnCode }
+        }
+    }
+
+    private SystemCall mockSystem(Closure<Integer> handler) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return handler(cmd) }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return handler(cmd) }
+        }
+    }
+
+    def "prepare() returns true when node and npm are found"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == true
+    }
+
+    def "prepare() returns false when node is not found"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("node") ? 1 : 0
+        }
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "prepare() returns false when npm is not found"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("npm") ? 1 : 0
+        }
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "prepare() logs node_version when provided in buildConfig"() {
+        given:
+        def system = mockSystem(0)
+        def messages = []
+        def ctx = [
+            echo: { msg -> messages << msg },
+            withEnv: { List<String> vars, Closure body -> body.call() }
+        ]
+        def adapter = new NodeAdapter(ctx, system)
+
+        when:
+        adapter.prepare([node_version: "20"], ctx)
+
+        then:
+        messages.any { it.contains("20") }
+    }
+
+    def "lint() happy path returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+    }
+
+    def "lint() returns true even when lint command fails (non-fatal)"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+    }
+
+    def "test() happy path returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == true
+    }
+
+    def "test() returns false when npm test fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == false
+    }
+
+    def "test() uses custom test_command from buildConfig"() {
+        given:
+        def executedCommands = []
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                executedCommands << cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                executedCommands << cmd
+                return 0
+            }
+        }
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([test_command: "yarn test"])
+
+        then:
+        result == true
+        // The env var CIORCH_CMD is set to "yarn test" and the shell uses it
+    }
+
+    def "build() happy path returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == true
+    }
+
+    def "build() returns false when npm run build fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+    }
+
+    def "build() uses custom build_command from buildConfig"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([build_command: "yarn build"])
+
+        then:
+        result == true
+    }
+
+    def "getArtifacts() returns non-empty list after successful build"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new NodeAdapter(mockContext, system)
+        adapter.build([:])
+
+        when:
+        List<String> artifacts = adapter.getArtifacts()
+
+        then:
+        artifacts != null
+        !artifacts.isEmpty()
+        artifacts.contains("dist/")
+    }
+
+    def "getArtifacts() returns empty list before build"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        List<String> artifacts = adapter.getArtifacts()
+
+        then:
+        artifacts.isEmpty()
+    }
+
+    def "getName() returns 'node'"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        String name = adapter.getName()
+
+        then:
+        name == "node"
+    }
+}

--- a/tests/unit/groovy/NodeAdapterTest.groovy
+++ b/tests/unit/groovy/NodeAdapterTest.groovy
@@ -98,7 +98,7 @@ class NodeAdapterTest extends Specification {
         result == true
     }
 
-    def "lint() returns true even when lint command fails (non-fatal)"() {
+    def "lint() returns false when lint command fails"() {
         given:
         def system = mockSystem(1)
         def adapter = new NodeAdapter(mockContext, system)
@@ -107,10 +107,10 @@ class NodeAdapterTest extends Specification {
         boolean result = adapter.lint([:])
 
         then:
-        result == true
+        result == false
     }
 
-    def "lint() uses custom lintCommand from buildConfig"() {
+    def "lint() uses custom lint_command from buildConfig"() {
         given:
         def capturedCmd = null
         def system = mockSystem { String cmd ->
@@ -121,7 +121,7 @@ class NodeAdapterTest extends Specification {
         def adapter = new NodeAdapter(null, system)
 
         when:
-        boolean result = adapter.lint([lintCommand: 'my-custom-lint'])
+        boolean result = adapter.lint([lint_command: 'my-custom-lint'])
 
         then:
         result == true
@@ -154,27 +154,28 @@ class NodeAdapterTest extends Specification {
 
     def "test() uses custom test_command from buildConfig"() {
         given:
-        def executedCommands = []
+        def capturedCmd = null
         def system = new SystemCall(null, "", "", "", "") {
             @Override
             def run_command(String cmd, int mode) {
-                executedCommands << cmd
+                capturedCmd = cmd
                 return 0
             }
             @Override
             def run_command(String cmd, int mode, int timeout) {
-                executedCommands << cmd
+                capturedCmd = cmd
                 return 0
             }
         }
-        def adapter = new NodeAdapter(mockContext, system)
+        // null context so withEnv is skipped and the fallback fires with testCmd directly
+        def adapter = new NodeAdapter(null, system)
 
         when:
         boolean result = adapter.test([test_command: "yarn test"])
 
         then:
         result == true
-        // The env var CIORCH_CMD is set to "yarn test" and the shell uses it
+        capturedCmd == 'yarn test'
     }
 
     def "build() happy path returns true"() {
@@ -203,14 +204,28 @@ class NodeAdapterTest extends Specification {
 
     def "build() uses custom build_command from buildConfig"() {
         given:
-        def system = mockSystem(0)
-        def adapter = new NodeAdapter(mockContext, system)
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with buildCmd directly
+        def adapter = new NodeAdapter(null, system)
 
         when:
         boolean result = adapter.build([build_command: "yarn build"])
 
         then:
         result == true
+        capturedCmd == 'yarn build'
     }
 
     def "getArtifacts() returns non-empty list after successful build"() {

--- a/tests/unit/groovy/NodeAdapterTest.groovy
+++ b/tests/unit/groovy/NodeAdapterTest.groovy
@@ -1,6 +1,7 @@
 package io.ciorch.tests
 
 import io.ciorch.build.adapters.NodeAdapter
+import io.ciorch.core.Config
 import io.ciorch.core.SystemCall
 import spock.lang.Specification
 
@@ -55,10 +56,13 @@ class NodeAdapterTest extends Specification {
         result == false
     }
 
-    def "prepare() returns false when npm is not found"() {
+    def "prepare() returns false when no package manager is found"() {
         given:
         def system = mockSystem { String cmd ->
-            cmd.contains("npm") ? 1 : 0
+            if (cmd.contains("test -f yarn.lock")) return 1
+            if (cmd.contains("test -f pnpm-lock.yaml")) return 1
+            if (cmd.contains("npm --version")) return 1
+            return 0
         }
         def adapter = new NodeAdapter(mockContext, system)
 
@@ -67,6 +71,58 @@ class NodeAdapterTest extends Specification {
 
         then:
         result == false
+    }
+
+    def "prepare() detects yarn when yarn.lock is present"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("test -f yarn.lock")) return 0
+            return 0
+        }
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == true
+        adapter.packageManager == "yarn"
+    }
+
+    def "prepare() detects pnpm when pnpm-lock.yaml is present"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("test -f yarn.lock")) return 1
+            if (cmd.contains("test -f pnpm-lock.yaml")) return 0
+            return 0
+        }
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == true
+        adapter.packageManager == "pnpm"
+    }
+
+    def "prepare() logs node_version from config.toolVersions when absent in buildConfig"() {
+        given:
+        def config = new Config()
+        config.toolVersions = [node_version: "18"]
+        def system = mockSystem(0)
+        def messages = []
+        def ctx = [
+            echo: { msg -> messages << msg },
+            withEnv: { List<String> vars, Closure body -> body.call() }
+        ]
+        def adapter = new NodeAdapter(ctx, system, config)
+
+        when:
+        adapter.prepare([:], ctx)
+
+        then:
+        messages.any { it.contains("18") }
     }
 
     def "prepare() logs node_version when provided in buildConfig"() {

--- a/tests/unit/groovy/NodeAdapterTest.groovy
+++ b/tests/unit/groovy/NodeAdapterTest.groovy
@@ -281,6 +281,56 @@ class NodeAdapterTest extends Specification {
         capturedCmd == 'yarn build'
     }
 
+    def "build() leaves artifacts empty for custom build_command without artifact override"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([build_command: "next build"])
+
+        then:
+        result == true
+        adapter.getArtifacts() == []
+    }
+
+    def "build() uses explicit artifacts for custom build_command"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new NodeAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([
+            build_command: "next build",
+            artifacts: [".next/"]
+        ])
+
+        then:
+        result == true
+        adapter.getArtifacts() == [".next/"]
+    }
+
+    def "build() uses artifacts from raw config for custom build_command"() {
+        given:
+        def config = new Config()
+        config.raw = [
+            ciorch: [
+                build: [
+                    artifacts: "build/"
+                ]
+            ]
+        ]
+        def system = mockSystem(0)
+        def adapter = new NodeAdapter(mockContext, system, config)
+
+        when:
+        boolean result = adapter.build([build_command: "react-scripts build"])
+
+        then:
+        result == true
+        adapter.getArtifacts() == ["build/"]
+    }
+
     def "getArtifacts() returns non-empty list after successful build"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/NodeAdapterTest.groovy
+++ b/tests/unit/groovy/NodeAdapterTest.groovy
@@ -173,7 +173,6 @@ class NodeAdapterTest extends Specification {
             capturedCmd = cmd
             return 0
         }
-        // null context so withEnv is skipped and the fallback fires with lintCmd directly
         def adapter = new NodeAdapter(null, system)
 
         when:
@@ -223,7 +222,6 @@ class NodeAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with testCmd directly
         def adapter = new NodeAdapter(null, system)
 
         when:
@@ -273,7 +271,6 @@ class NodeAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with buildCmd directly
         def adapter = new NodeAdapter(null, system)
 
         when:

--- a/tests/unit/groovy/NodeAdapterTest.groovy
+++ b/tests/unit/groovy/NodeAdapterTest.groovy
@@ -296,6 +296,21 @@ class NodeAdapterTest extends Specification {
         artifacts.contains("dist/")
     }
 
+    def "build() clears stale artifacts when command fails after a successful build"() {
+        given:
+        def results = [0, 1]
+        def system = mockSystem { String cmd -> results.remove(0) }
+        def adapter = new NodeAdapter(mockContext, system)
+        adapter.build([:])
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+        adapter.getArtifacts().isEmpty()
+    }
+
     def "getArtifacts() returns empty list before build"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/PhpAdapterTest.groovy
+++ b/tests/unit/groovy/PhpAdapterTest.groovy
@@ -171,6 +171,32 @@ class PhpAdapterTest extends Specification {
         result == false
     }
 
+    def "lint() uses lint_command override when provided"() {
+        given:
+        def capturedCmd = null
+        def system = mockSystem { String cmd -> capturedCmd = cmd; return 0 }
+        def adapter = new PhpAdapter(null, system)
+
+        when:
+        boolean result = adapter.lint([lint_command: "php-cs-fixer fix --dry-run"])
+
+        then:
+        result == true
+        capturedCmd == "php-cs-fixer fix --dry-run"
+    }
+
+    def "lint() returns false when lint_command override fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([lint_command: "php-cs-fixer fix --dry-run"])
+
+        then:
+        result == false
+    }
+
     def "test() happy path returns true"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/PhpAdapterTest.groovy
+++ b/tests/unit/groovy/PhpAdapterTest.groovy
@@ -106,7 +106,7 @@ class PhpAdapterTest extends Specification {
 
         then:
         result == true
-        executedCommands.any { it.contains("php -l src/") }
+        executedCommands.any { it.contains("find src") && it.contains("php -l") }
     }
 
     def "lint() returns false when lint command fails"() {

--- a/tests/unit/groovy/PhpAdapterTest.groovy
+++ b/tests/unit/groovy/PhpAdapterTest.groovy
@@ -109,9 +109,59 @@ class PhpAdapterTest extends Specification {
         executedCommands.any { it.contains("find src") && it.contains("php -l") }
     }
 
-    def "lint() returns false when lint command fails"() {
+    def "lint() skips php -l fallback when src/ does not exist"() {
         given:
-        def system = mockSystem(1)
+        def executedCommands = []
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                executedCommands << cmd
+                if (cmd.contains("test -x vendor/bin/phpcs")) return 1  // phpcs absent
+                if (cmd.contains("test -d src")) return 1               // src/ absent
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                executedCommands << cmd
+                if (cmd.contains("test -x vendor/bin/phpcs")) return 1
+                if (cmd.contains("test -d src")) return 1
+                return 0
+            }
+        }
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+        !executedCommands.any { it.contains("find src") }
+    }
+
+    def "lint() returns false when phpcs is found but fails"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("test -x vendor/bin/phpcs")) return 0  // phpcs found
+            if (cmd.contains("vendor/bin/phpcs")) return 1          // phpcs run fails
+            return 0
+        }
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == false
+    }
+
+    def "lint() returns false when phpcs absent and php -l fails"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("test -x vendor/bin/phpcs")) return 1  // phpcs absent
+            if (cmd.contains("test -d src")) return 0               // src/ exists
+            if (cmd.contains("find src")) return 1                  // php -l fails
+            return 0
+        }
         def adapter = new PhpAdapter(mockContext, system)
 
         when:

--- a/tests/unit/groovy/PhpAdapterTest.groovy
+++ b/tests/unit/groovy/PhpAdapterTest.groovy
@@ -109,7 +109,7 @@ class PhpAdapterTest extends Specification {
         executedCommands.any { it.contains("php -l src/") }
     }
 
-    def "lint() returns true even when lint fails (non-fatal)"() {
+    def "lint() returns false when lint command fails"() {
         given:
         def system = mockSystem(1)
         def adapter = new PhpAdapter(mockContext, system)
@@ -118,7 +118,7 @@ class PhpAdapterTest extends Specification {
         boolean result = adapter.lint([:])
 
         then:
-        result == true
+        result == false
     }
 
     def "test() happy path returns true"() {
@@ -147,14 +147,28 @@ class PhpAdapterTest extends Specification {
 
     def "test() uses custom test_command from buildConfig"() {
         given:
-        def system = mockSystem(0)
-        def adapter = new PhpAdapter(mockContext, system)
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with testCmd directly
+        def adapter = new PhpAdapter(null, system)
 
         when:
         boolean result = adapter.test([test_command: "php artisan test"])
 
         then:
         result == true
+        capturedCmd == 'php artisan test'
     }
 
     def "build() happy path returns true"() {
@@ -183,14 +197,28 @@ class PhpAdapterTest extends Specification {
 
     def "build() uses custom build_command from buildConfig"() {
         given:
-        def system = mockSystem(0)
-        def adapter = new PhpAdapter(mockContext, system)
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with buildCmd directly
+        def adapter = new PhpAdapter(null, system)
 
         when:
         boolean result = adapter.build([build_command: "composer install"])
 
         then:
         result == true
+        capturedCmd == 'composer install'
     }
 
     def "getArtifacts() returns non-empty list after successful build"() {

--- a/tests/unit/groovy/PhpAdapterTest.groovy
+++ b/tests/unit/groovy/PhpAdapterTest.groovy
@@ -1,0 +1,234 @@
+package io.ciorch.tests
+
+import io.ciorch.build.adapters.PhpAdapter
+import io.ciorch.core.SystemCall
+import spock.lang.Specification
+
+class PhpAdapterTest extends Specification {
+
+    def mockContext = [
+        echo: { msg -> },
+        withEnv: { List<String> vars, Closure body -> body.call() }
+    ]
+
+    private SystemCall mockSystem(int returnCode) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return returnCode }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return returnCode }
+        }
+    }
+
+    private SystemCall mockSystem(Closure<Integer> handler) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return handler(cmd) }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return handler(cmd) }
+        }
+    }
+
+    def "prepare() returns true when php and composer are found"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == true
+    }
+
+    def "prepare() returns false when php is not found"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("php --version") ? 1 : 0
+        }
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "prepare() returns false when composer is not found"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("composer --version") ? 1 : 0
+        }
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "lint() happy path returns true when phpcs is available"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+    }
+
+    def "lint() falls back to php -l when phpcs not found"() {
+        given:
+        def executedCommands = []
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                executedCommands << cmd
+                // phpcs not found, fallback to php -l
+                if (cmd.contains("test -x vendor/bin/phpcs")) return 1
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                executedCommands << cmd
+                if (cmd.contains("test -x vendor/bin/phpcs")) return 1
+                return 0
+            }
+        }
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+        executedCommands.any { it.contains("php -l src/") }
+    }
+
+    def "lint() returns true even when lint fails (non-fatal)"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+    }
+
+    def "test() happy path returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == true
+    }
+
+    def "test() returns false when phpunit fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == false
+    }
+
+    def "test() uses custom test_command from buildConfig"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([test_command: "php artisan test"])
+
+        then:
+        result == true
+    }
+
+    def "build() happy path returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == true
+    }
+
+    def "build() returns false when composer install fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+    }
+
+    def "build() uses custom build_command from buildConfig"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([build_command: "composer install"])
+
+        then:
+        result == true
+    }
+
+    def "getArtifacts() returns non-empty list after successful build"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PhpAdapter(mockContext, system)
+        adapter.build([:])
+
+        when:
+        List<String> artifacts = adapter.getArtifacts()
+
+        then:
+        artifacts != null
+        !artifacts.isEmpty()
+        artifacts.contains("vendor/")
+    }
+
+    def "getArtifacts() returns empty list before build"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        List<String> artifacts = adapter.getArtifacts()
+
+        then:
+        artifacts.isEmpty()
+    }
+
+    def "getName() returns 'php'"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        String name = adapter.getName()
+
+        then:
+        name == "php"
+    }
+}

--- a/tests/unit/groovy/PhpAdapterTest.groovy
+++ b/tests/unit/groovy/PhpAdapterTest.groovy
@@ -106,10 +106,10 @@ class PhpAdapterTest extends Specification {
 
         then:
         result == true
-        executedCommands.any { it.contains("find src") && it.contains("php -l") }
+        executedCommands.any { it.contains("find .") && it.contains("php -l") && it.contains("./vendor -prune") }
     }
 
-    def "lint() skips php -l fallback when src/ does not exist"() {
+    def "lint() runs php -l repository fallback when src does not exist"() {
         given:
         def executedCommands = []
         def system = new SystemCall(null, "", "", "", "") {
@@ -117,14 +117,14 @@ class PhpAdapterTest extends Specification {
             def run_command(String cmd, int mode) {
                 executedCommands << cmd
                 if (cmd.contains("test -x vendor/bin/phpcs")) return 1  // phpcs absent
-                if (cmd.contains("test -d src")) return 1               // src/ absent
+                if (cmd.contains("find .")) return 0
                 return 0
             }
             @Override
             def run_command(String cmd, int mode, int timeout) {
                 executedCommands << cmd
                 if (cmd.contains("test -x vendor/bin/phpcs")) return 1
-                if (cmd.contains("test -d src")) return 1
+                if (cmd.contains("find .")) return 0
                 return 0
             }
         }
@@ -135,7 +135,7 @@ class PhpAdapterTest extends Specification {
 
         then:
         result == true
-        !executedCommands.any { it.contains("find src") }
+        executedCommands.any { it.contains("find .") && it.contains("php -l") && it.contains("./vendor -prune") }
     }
 
     def "lint() returns false when phpcs is found but fails"() {
@@ -158,8 +158,7 @@ class PhpAdapterTest extends Specification {
         given:
         def system = mockSystem { String cmd ->
             if (cmd.contains("test -x vendor/bin/phpcs")) return 1  // phpcs absent
-            if (cmd.contains("test -d src")) return 0               // src/ exists
-            if (cmd.contains("find src")) return 1                  // php -l fails
+            if (cmd.contains("find .")) return 1                    // php -l fails
             return 0
         }
         def adapter = new PhpAdapter(mockContext, system)

--- a/tests/unit/groovy/PhpAdapterTest.groovy
+++ b/tests/unit/groovy/PhpAdapterTest.groovy
@@ -310,6 +310,21 @@ class PhpAdapterTest extends Specification {
         artifacts.contains("vendor/")
     }
 
+    def "build() clears stale artifacts when command fails after a successful build"() {
+        given:
+        def results = [0, 1]
+        def system = mockSystem { String cmd -> results.remove(0) }
+        def adapter = new PhpAdapter(mockContext, system)
+        adapter.build([:])
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+        adapter.getArtifacts().isEmpty()
+    }
+
     def "getArtifacts() returns empty list before build"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/PhpAdapterTest.groovy
+++ b/tests/unit/groovy/PhpAdapterTest.groovy
@@ -293,6 +293,23 @@ class PhpAdapterTest extends Specification {
         then:
         result == true
         capturedCmd == 'composer install'
+        adapter.getArtifacts().isEmpty()
+    }
+
+    def "build() uses explicit artifacts for custom build_command"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PhpAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([
+            build_command: "composer archive",
+            artifacts: ["release/"]
+        ])
+
+        then:
+        result == true
+        adapter.getArtifacts() == ["release/"]
     }
 
     def "getArtifacts() returns non-empty list after successful build"() {

--- a/tests/unit/groovy/PhpAdapterTest.groovy
+++ b/tests/unit/groovy/PhpAdapterTest.groovy
@@ -236,7 +236,6 @@ class PhpAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with testCmd directly
         def adapter = new PhpAdapter(null, system)
 
         when:
@@ -286,7 +285,6 @@ class PhpAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with buildCmd directly
         def adapter = new PhpAdapter(null, system)
 
         when:

--- a/tests/unit/groovy/PipelineOrchestratorTest.groovy
+++ b/tests/unit/groovy/PipelineOrchestratorTest.groovy
@@ -1,0 +1,104 @@
+package io.ciorch.tests
+
+import io.ciorch.build.BuildAdapter
+import io.ciorch.core.Config
+import io.ciorch.core.PipelineOrchestrator
+import io.ciorch.core.SystemCall
+import spock.lang.Specification
+
+import java.lang.reflect.Method
+
+class PipelineOrchestratorTest extends Specification {
+
+    def mockContext = [
+        echo: { msg -> },
+        withEnv: { List<String> vars, Closure body -> body.call() }
+    ]
+
+    private SystemCall mockSystem(int returnCode = 0) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return returnCode }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return returnCode }
+        }
+    }
+
+    // Controllable adapter registered as a real Class so _resolveBuildAdapter can instantiate it.
+    // Static counters are safe here because Spock runs tests sequentially.
+    static class CountingAdapter implements BuildAdapter, Serializable {
+        static int prepareCallCount = 0
+        static boolean prepareResult = true
+
+        CountingAdapter(def context, SystemCall system, Config config) {}
+
+        @Override boolean prepare(Map cfg, def context) { prepareCallCount++; return prepareResult }
+        @Override boolean lint(Map cfg)  { return true }
+        @Override boolean test(Map cfg)  { return true }
+        @Override boolean build(Map cfg) { return true }
+        @Override List<String> getArtifacts() { return [] }
+        @Override String getName() { return "counting" }
+
+        static void reset(boolean result = true) { prepareCallCount = 0; prepareResult = result }
+    }
+
+    def setup() {
+        PipelineOrchestrator.registerBuildAdapter("counting", CountingAdapter)
+    }
+
+    // Reflection helpers to access private methods without MOP arg-wrapping ambiguity
+    private static boolean dispatchTasks(PipelineOrchestrator orch, List<String> tasks) {
+        Method m = PipelineOrchestrator.class.getDeclaredMethod("_dispatchTasks", List.class)
+        m.setAccessible(true)
+        return m.invoke(orch, tasks) as boolean
+    }
+
+    private static boolean runBuildStep(PipelineOrchestrator orch, String step) {
+        Method m = PipelineOrchestrator.class.getDeclaredMethod("_runBuildStep", String.class)
+        m.setAccessible(true)
+        return m.invoke(orch, step) as boolean
+    }
+
+    def "prepare() is called only once when multiple build steps run"() {
+        given:
+        CountingAdapter.reset(true)
+        def cfg = new Config()
+        cfg.buildAdapter = "counting"
+        def orch = new PipelineOrchestrator(mockContext, cfg, mockSystem())
+
+        when:
+        dispatchTasks(orch, ["lint", "test", "build"])
+
+        then:
+        CountingAdapter.prepareCallCount == 1
+    }
+
+    def "prepare() failure aborts the build step and returns false"() {
+        given:
+        CountingAdapter.reset(false)
+        def cfg = new Config()
+        cfg.buildAdapter = "counting"
+        def orch = new PipelineOrchestrator(mockContext, cfg, mockSystem())
+
+        when:
+        boolean result = runBuildStep(orch, "lint")
+
+        then:
+        result == false
+        CountingAdapter.prepareCallCount == 1
+    }
+
+    def "prepare() failure halts dispatch after first failing task"() {
+        given:
+        CountingAdapter.reset(false)
+        def cfg = new Config()
+        cfg.buildAdapter = "counting"
+        def orch = new PipelineOrchestrator(mockContext, cfg, mockSystem())
+
+        when:
+        boolean result = dispatchTasks(orch, ["lint", "test"])
+
+        then:
+        result == false
+    }
+}

--- a/tests/unit/groovy/PipelineOrchestratorTest.groovy
+++ b/tests/unit/groovy/PipelineOrchestratorTest.groovy
@@ -46,6 +46,12 @@ class PipelineOrchestratorTest extends Specification {
         PipelineOrchestrator.registerBuildAdapter("counting", CountingAdapter)
     }
 
+    def cleanup() {
+        def field = PipelineOrchestrator.class.getDeclaredField("BUILD_REGISTRY")
+        field.setAccessible(true)
+        ((Map) field.get(null)).remove("counting")
+    }
+
     // Reflection helpers to access private methods without MOP arg-wrapping ambiguity
     private static boolean dispatchTasks(PipelineOrchestrator orch, List<String> tasks) {
         Method m = PipelineOrchestrator.class.getDeclaredMethod("_dispatchTasks", List.class)

--- a/tests/unit/groovy/PythonAdapterTest.groovy
+++ b/tests/unit/groovy/PythonAdapterTest.groovy
@@ -193,6 +193,32 @@ class PythonAdapterTest extends Specification {
         result == true
     }
 
+    def "lint() uses lint_command override when provided"() {
+        given:
+        def capturedCmd = null
+        def system = mockSystem { String cmd -> capturedCmd = cmd; return 0 }
+        def adapter = new PythonAdapter(null, system)
+
+        when:
+        boolean result = adapter.lint([lint_command: "pylint src/"])
+
+        then:
+        result == true
+        capturedCmd == "pylint src/"
+    }
+
+    def "lint() returns false when lint_command override fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([lint_command: "pylint src/"])
+
+        then:
+        result == false
+    }
+
     def "test() happy path returns true"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/PythonAdapterTest.groovy
+++ b/tests/unit/groovy/PythonAdapterTest.groovy
@@ -1,0 +1,351 @@
+package io.ciorch.tests
+
+import io.ciorch.build.adapters.PythonAdapter
+import io.ciorch.core.SystemCall
+import spock.lang.Specification
+
+class PythonAdapterTest extends Specification {
+
+    def mockContext = [
+        echo: { msg -> },
+        withEnv: { List<String> vars, Closure body -> body.call() }
+    ]
+
+    private SystemCall mockSystem(int returnCode) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return returnCode }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return returnCode }
+        }
+    }
+
+    private SystemCall mockSystem(Closure<Integer> handler) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return handler(cmd) }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return handler(cmd) }
+        }
+    }
+
+    def "prepare() returns true when python3 is found"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == true
+    }
+
+    def "prepare() returns false when python3 and python are not found"() {
+        given:
+        def system = mockSystem { String cmd ->
+            (cmd.contains("python3 --version") || cmd.contains("python --version")) ? 1 : 0
+        }
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "prepare() detects poetry when pyproject.toml and poetry.lock are present"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("python3 --version")) return 0
+            if (cmd.contains("poetry.lock")) return 0
+            return 1
+        }
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        adapter.prepare([:], mockContext)
+
+        then:
+        adapter.packageManager == "poetry"
+    }
+
+    def "prepare() detects uv when pyproject.toml and uv.lock are present"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("python3 --version")) return 0
+            if (cmd.contains("poetry.lock")) return 1
+            if (cmd.contains("uv.lock")) return 0
+            return 1
+        }
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        adapter.prepare([:], mockContext)
+
+        then:
+        adapter.packageManager == "uv"
+    }
+
+    def "prepare() defaults to pip when no lock files found"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("python3 --version")) return 0
+            return 1
+        }
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        adapter.prepare([:], mockContext)
+
+        then:
+        adapter.packageManager == "pip"
+    }
+
+    def "lint() returns true when ruff is available and passes"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("which ruff") ? 0 : 0
+        }
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+    }
+
+    def "lint() returns false when ruff fails"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("which ruff")) return 0
+            if (cmd.contains("ruff check")) return 1
+            return 0
+        }
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == false
+    }
+
+    def "lint() falls back to flake8 when ruff not available"() {
+        given:
+        def executedCommands = []
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                executedCommands << cmd
+                if (cmd.contains("which ruff")) return 1
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                executedCommands << cmd
+                if (cmd.contains("which ruff")) return 1
+                return 0
+            }
+        }
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+        executedCommands.any { it.contains("flake8") }
+    }
+
+    def "lint() returns false when flake8 fails"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("which ruff")) return 1
+            if (cmd.contains("which flake8")) return 0
+            if (cmd.contains("flake8 .")) return 1
+            return 0
+        }
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == false
+    }
+
+    def "lint() skips non-fatally when neither ruff nor flake8 available"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("python3 --version")) return 0
+            if (cmd.contains("which")) return 1
+            return 0
+        }
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+    }
+
+    def "test() happy path returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == true
+    }
+
+    def "test() returns false when pytest fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == false
+    }
+
+    def "test() uses custom test_command from buildConfig"() {
+        given:
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with testCmd directly
+        def adapter = new PythonAdapter(null, system)
+
+        when:
+        boolean result = adapter.test([test_command: "python -m pytest -v tests/"])
+
+        then:
+        result == true
+        capturedCmd == 'python -m pytest -v tests/'
+    }
+
+    def "build() happy path with poetry returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PythonAdapter(mockContext, system)
+        adapter.packageManager = "poetry"
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == true
+    }
+
+    def "build() happy path with uv returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PythonAdapter(mockContext, system)
+        adapter.packageManager = "uv"
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == true
+    }
+
+    def "build() pip manager is a no-op returning true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PythonAdapter(mockContext, system)
+        adapter.packageManager = "pip"
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == true
+    }
+
+    def "build() uses custom build_command from buildConfig"() {
+        given:
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with buildCmd directly
+        def adapter = new PythonAdapter(null, system)
+        adapter.packageManager = "poetry"
+
+        when:
+        boolean result = adapter.build([build_command: "poetry build --format wheel"])
+
+        then:
+        result == true
+        capturedCmd == 'poetry build --format wheel'
+    }
+
+    def "getArtifacts() returns non-empty list after successful build"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PythonAdapter(mockContext, system)
+        adapter.packageManager = "poetry"
+        adapter.build([:])
+
+        when:
+        List<String> artifacts = adapter.getArtifacts()
+
+        then:
+        artifacts != null
+        !artifacts.isEmpty()
+        artifacts.contains("dist/")
+    }
+
+    def "getArtifacts() returns empty list before build"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        List<String> artifacts = adapter.getArtifacts()
+
+        then:
+        artifacts.isEmpty()
+    }
+
+    def "getName() returns 'python'"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        String name = adapter.getName()
+
+        then:
+        name == "python"
+    }
+}

--- a/tests/unit/groovy/PythonAdapterTest.groovy
+++ b/tests/unit/groovy/PythonAdapterTest.groovy
@@ -217,6 +217,32 @@ class PythonAdapterTest extends Specification {
         result == false
     }
 
+    def "prepare() with python3 sets pythonCmd correctly (test() default uses python3)"() {
+        given:
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with testCmd directly
+        def adapter = new PythonAdapter(null, system)
+        adapter.prepare([:], null)
+
+        when:
+        adapter.test([:])
+
+        then:
+        capturedCmd.startsWith("python3")
+    }
+
     def "test() uses custom test_command from buildConfig"() {
         given:
         def capturedCmd = null
@@ -280,6 +306,19 @@ class PythonAdapterTest extends Specification {
 
         then:
         result == true
+    }
+
+    def "build() with pip manager returns no artifacts"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PythonAdapter(mockContext, system)
+        adapter.packageManager = "pip"
+
+        when:
+        adapter.build([:])
+
+        then:
+        adapter.getArtifacts() == []
     }
 
     def "build() uses custom build_command from buildConfig"() {

--- a/tests/unit/groovy/PythonAdapterTest.groovy
+++ b/tests/unit/groovy/PythonAdapterTest.groovy
@@ -1,6 +1,7 @@
 package io.ciorch.tests
 
 import io.ciorch.build.adapters.PythonAdapter
+import io.ciorch.core.Config
 import io.ciorch.core.SystemCall
 import spock.lang.Specification
 
@@ -406,6 +407,59 @@ class PythonAdapterTest extends Specification {
         then:
         result == true
         capturedCmd == 'poetry build --format wheel'
+    }
+
+    def "build() leaves artifacts empty for custom build_command without artifact override"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PythonAdapter(mockContext, system)
+        adapter.packageManager = "poetry"
+
+        when:
+        boolean result = adapter.build([build_command: "python -m build --wheel --outdir wheelhouse"])
+
+        then:
+        result == true
+        adapter.getArtifacts() == []
+    }
+
+    def "build() uses explicit artifacts for custom build_command"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PythonAdapter(mockContext, system)
+        adapter.packageManager = "poetry"
+
+        when:
+        boolean result = adapter.build([
+            build_command: "python -m build --wheel --outdir wheelhouse",
+            artifacts: ["wheelhouse/"]
+        ])
+
+        then:
+        result == true
+        adapter.getArtifacts() == ["wheelhouse/"]
+    }
+
+    def "build() uses artifacts from raw config for custom build_command"() {
+        given:
+        def config = new Config()
+        config.raw = [
+            ciorch: [
+                build: [
+                    artifacts: "custom-dist/"
+                ]
+            ]
+        ]
+        def system = mockSystem(0)
+        def adapter = new PythonAdapter(mockContext, system, config)
+        adapter.packageManager = "poetry"
+
+        when:
+        boolean result = adapter.build([build_command: "python -m build"])
+
+        then:
+        result == true
+        adapter.getArtifacts() == ["custom-dist/"]
     }
 
     def "getArtifacts() returns non-empty list after successful build"() {

--- a/tests/unit/groovy/PythonAdapterTest.groovy
+++ b/tests/unit/groovy/PythonAdapterTest.groovy
@@ -460,6 +460,20 @@ class PythonAdapterTest extends Specification {
         adapter.getArtifacts() == []
     }
 
+    def "build() keeps default artifacts when explicit build_command matches poetry default"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PythonAdapter(mockContext, system)
+        adapter.packageManager = "poetry"
+
+        when:
+        boolean result = adapter.build([build_command: "poetry build"])
+
+        then:
+        result == true
+        adapter.getArtifacts() == ["dist/"]
+    }
+
     def "build() uses explicit artifacts for custom build_command"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/PythonAdapterTest.groovy
+++ b/tests/unit/groovy/PythonAdapterTest.groovy
@@ -345,6 +345,43 @@ class PythonAdapterTest extends Specification {
         adapter.getArtifacts() == []
     }
 
+    def "build() with pip manager clears stale artifacts"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new PythonAdapter(mockContext, system)
+        adapter.packageManager = "poetry"
+        adapter.build([:])
+        adapter.getArtifacts() == ["dist/"]
+
+        when:
+        adapter.packageManager = "pip"
+        boolean result = adapter.build([:])
+
+        then:
+        result == true
+        adapter.getArtifacts() == []
+    }
+
+    def "build() failure clears stale artifacts"() {
+        given:
+        int buildCount = 0
+        def system = mockSystem { String cmd ->
+            buildCount++
+            return buildCount == 1 ? 0 : 1
+        }
+        def adapter = new PythonAdapter(mockContext, system)
+        adapter.packageManager = "poetry"
+        adapter.build([:])
+        adapter.getArtifacts() == ["dist/"]
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+        adapter.getArtifacts() == []
+    }
+
     def "build() uses custom build_command from buildConfig"() {
         given:
         def capturedCmd = null

--- a/tests/unit/groovy/PythonAdapterTest.groovy
+++ b/tests/unit/groovy/PythonAdapterTest.groovy
@@ -258,7 +258,6 @@ class PythonAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with testCmd directly
         def adapter = new PythonAdapter(null, system)
         adapter.prepare([:], null)
 
@@ -284,7 +283,6 @@ class PythonAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with testCmd directly
         def adapter = new PythonAdapter(null, system)
 
         when:
@@ -362,7 +360,6 @@ class PythonAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with buildCmd directly
         def adapter = new PythonAdapter(null, system)
         adapter.packageManager = "poetry"
 

--- a/tests/unit/groovy/PythonAdapterTest.groovy
+++ b/tests/unit/groovy/PythonAdapterTest.groovy
@@ -61,6 +61,7 @@ class PythonAdapterTest extends Specification {
         def system = mockSystem { String cmd ->
             if (cmd.contains("python3 --version")) return 0
             if (cmd.contains("poetry.lock")) return 0
+            if (cmd.contains("poetry --version")) return 0
             return 1
         }
         def adapter = new PythonAdapter(mockContext, system)
@@ -72,12 +73,30 @@ class PythonAdapterTest extends Specification {
         adapter.packageManager == "poetry"
     }
 
+    def "prepare() returns false when poetry lock exists but poetry is unavailable"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("python3 --version")) return 0
+            if (cmd.contains("poetry.lock")) return 0
+            if (cmd.contains("poetry --version")) return 1
+            return 1
+        }
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == false
+    }
+
     def "prepare() detects uv when pyproject.toml and uv.lock are present"() {
         given:
         def system = mockSystem { String cmd ->
             if (cmd.contains("python3 --version")) return 0
             if (cmd.contains("poetry.lock")) return 1
             if (cmd.contains("uv.lock")) return 0
+            if (cmd.contains("uv --version")) return 0
             return 1
         }
         def adapter = new PythonAdapter(mockContext, system)
@@ -87,6 +106,24 @@ class PythonAdapterTest extends Specification {
 
         then:
         adapter.packageManager == "uv"
+    }
+
+    def "prepare() returns false when uv lock exists but uv is unavailable"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("python3 --version")) return 0
+            if (cmd.contains("poetry.lock")) return 1
+            if (cmd.contains("uv.lock")) return 0
+            if (cmd.contains("uv --version")) return 1
+            return 1
+        }
+        def adapter = new PythonAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == false
     }
 
     def "prepare() defaults to pip when no lock files found"() {

--- a/tests/unit/groovy/RustAdapterTest.groovy
+++ b/tests/unit/groovy/RustAdapterTest.groovy
@@ -128,6 +128,32 @@ class RustAdapterTest extends Specification {
         result == true
     }
 
+    def "lint() uses lint_command override when provided"() {
+        given:
+        def capturedCmd = null
+        def system = mockSystem { String cmd -> capturedCmd = cmd; return 0 }
+        def adapter = new RustAdapter(null, system)
+
+        when:
+        boolean result = adapter.lint([lint_command: "my-rust-linter"])
+
+        then:
+        result == true
+        capturedCmd == "my-rust-linter"
+    }
+
+    def "lint() returns false when lint_command override fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new RustAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([lint_command: "my-rust-linter"])
+
+        then:
+        result == false
+    }
+
     def "test() happy path returns true"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/RustAdapterTest.groovy
+++ b/tests/unit/groovy/RustAdapterTest.groovy
@@ -1,0 +1,269 @@
+package io.ciorch.tests
+
+import io.ciorch.build.adapters.RustAdapter
+import io.ciorch.core.SystemCall
+import spock.lang.Specification
+
+class RustAdapterTest extends Specification {
+
+    def mockContext = [
+        echo: { msg -> },
+        withEnv: { List<String> vars, Closure body -> body.call() }
+    ]
+
+    private SystemCall mockSystem(int returnCode) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return returnCode }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return returnCode }
+        }
+    }
+
+    private SystemCall mockSystem(Closure<Integer> handler) {
+        return new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) { return handler(cmd) }
+            @Override
+            def run_command(String cmd, int mode, int timeout) { return handler(cmd) }
+        }
+    }
+
+    def "prepare() returns true when cargo is found and fetch succeeds"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new RustAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == true
+    }
+
+    def "prepare() returns false when cargo is not found"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("cargo --version") ? 1 : 0
+        }
+        def adapter = new RustAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "prepare() returns false when cargo fetch fails"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("cargo fetch") ? 1 : 0
+        }
+        def adapter = new RustAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.prepare([:], mockContext)
+
+        then:
+        result == false
+    }
+
+    def "lint() happy path returns true when clippy passes and rustfmt available"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new RustAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+    }
+
+    def "lint() returns false when cargo clippy fails"() {
+        given:
+        def system = mockSystem { String cmd ->
+            cmd.contains("cargo clippy") ? 1 : 0
+        }
+        def adapter = new RustAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == false
+    }
+
+    def "lint() returns false when cargo fmt --check fails"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("cargo clippy")) return 0
+            if (cmd.contains("which rustfmt")) return 0
+            if (cmd.contains("cargo fmt --check")) return 1
+            return 0
+        }
+        def adapter = new RustAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == false
+    }
+
+    def "lint() skips fmt non-fatally when rustfmt not available"() {
+        given:
+        def system = mockSystem { String cmd ->
+            if (cmd.contains("cargo clippy")) return 0
+            if (cmd.contains("which rustfmt")) return 1
+            return 0
+        }
+        def adapter = new RustAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.lint([:])
+
+        then:
+        result == true
+    }
+
+    def "test() happy path returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new RustAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == true
+    }
+
+    def "test() returns false when cargo test fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new RustAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.test([:])
+
+        then:
+        result == false
+    }
+
+    def "test() uses custom test_command from buildConfig"() {
+        given:
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with testCmd directly
+        def adapter = new RustAdapter(null, system)
+
+        when:
+        boolean result = adapter.test([test_command: "cargo test --release"])
+
+        then:
+        result == true
+        capturedCmd == 'cargo test --release'
+    }
+
+    def "build() happy path returns true"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new RustAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == true
+    }
+
+    def "build() returns false when cargo build --release fails"() {
+        given:
+        def system = mockSystem(1)
+        def adapter = new RustAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+    }
+
+    def "build() uses custom build_command from buildConfig"() {
+        given:
+        def capturedCmd = null
+        def system = new SystemCall(null, "", "", "", "") {
+            @Override
+            def run_command(String cmd, int mode) {
+                capturedCmd = cmd
+                return 0
+            }
+            @Override
+            def run_command(String cmd, int mode, int timeout) {
+                capturedCmd = cmd
+                return 0
+            }
+        }
+        // null context so withEnv is skipped and the fallback fires with buildCmd directly
+        def adapter = new RustAdapter(null, system)
+
+        when:
+        boolean result = adapter.build([build_command: "cargo build --release --target x86_64-unknown-linux-musl"])
+
+        then:
+        result == true
+        capturedCmd == 'cargo build --release --target x86_64-unknown-linux-musl'
+    }
+
+    def "getArtifacts() returns non-empty list after successful build"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new RustAdapter(mockContext, system)
+        adapter.build([:])
+
+        when:
+        List<String> artifacts = adapter.getArtifacts()
+
+        then:
+        artifacts != null
+        !artifacts.isEmpty()
+        artifacts.contains("target/release/")
+    }
+
+    def "getArtifacts() returns empty list before build"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new RustAdapter(mockContext, system)
+
+        when:
+        List<String> artifacts = adapter.getArtifacts()
+
+        then:
+        artifacts.isEmpty()
+    }
+
+    def "getName() returns 'rust'"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new RustAdapter(mockContext, system)
+
+        when:
+        String name = adapter.getName()
+
+        then:
+        name == "rust"
+    }
+}

--- a/tests/unit/groovy/RustAdapterTest.groovy
+++ b/tests/unit/groovy/RustAdapterTest.groovy
@@ -193,7 +193,6 @@ class RustAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with testCmd directly
         def adapter = new RustAdapter(null, system)
 
         when:
@@ -243,7 +242,6 @@ class RustAdapterTest extends Specification {
                 return 0
             }
         }
-        // null context so withEnv is skipped and the fallback fires with buildCmd directly
         def adapter = new RustAdapter(null, system)
 
         when:

--- a/tests/unit/groovy/RustAdapterTest.groovy
+++ b/tests/unit/groovy/RustAdapterTest.groovy
@@ -1,6 +1,7 @@
 package io.ciorch.tests
 
 import io.ciorch.build.adapters.RustAdapter
+import io.ciorch.core.Config
 import io.ciorch.core.SystemCall
 import spock.lang.Specification
 
@@ -250,6 +251,44 @@ class RustAdapterTest extends Specification {
         then:
         result == true
         capturedCmd == 'cargo build --release --target x86_64-unknown-linux-musl'
+        adapter.getArtifacts().isEmpty()
+    }
+
+    def "build() uses explicit artifacts for custom build_command"() {
+        given:
+        def system = mockSystem(0)
+        def adapter = new RustAdapter(mockContext, system)
+
+        when:
+        boolean result = adapter.build([
+            build_command: "cargo build --release --target x86_64-unknown-linux-musl",
+            artifacts: ["target/x86_64-unknown-linux-musl/release/"]
+        ])
+
+        then:
+        result == true
+        adapter.getArtifacts() == ["target/x86_64-unknown-linux-musl/release/"]
+    }
+
+    def "build() uses artifacts from raw config for custom build_command"() {
+        given:
+        def config = new Config()
+        config.raw = [
+            ciorch: [
+                build: [
+                    artifacts: "target/debug/"
+                ]
+            ]
+        ]
+        def system = mockSystem(0)
+        def adapter = new RustAdapter(mockContext, system, config)
+
+        when:
+        boolean result = adapter.build([build_command: "cargo build"])
+
+        then:
+        result == true
+        adapter.getArtifacts() == ["target/debug/"]
     }
 
     def "getArtifacts() returns non-empty list after successful build"() {

--- a/tests/unit/groovy/RustAdapterTest.groovy
+++ b/tests/unit/groovy/RustAdapterTest.groovy
@@ -306,6 +306,21 @@ class RustAdapterTest extends Specification {
         artifacts.contains("target/release/")
     }
 
+    def "build() clears stale artifacts when command fails after a successful build"() {
+        given:
+        def results = [0, 1]
+        def system = mockSystem { String cmd -> results.remove(0) }
+        def adapter = new RustAdapter(mockContext, system)
+        adapter.build([:])
+
+        when:
+        boolean result = adapter.build([:])
+
+        then:
+        result == false
+        adapter.getArtifacts().isEmpty()
+    }
+
     def "getArtifacts() returns empty list before build"() {
         given:
         def system = mockSystem(0)

--- a/tests/unit/groovy/WebhookParserTest.groovy
+++ b/tests/unit/groovy/WebhookParserTest.groovy
@@ -175,4 +175,39 @@ class WebhookParserTest extends Specification {
         parser.srcType == BranchType.SPRINT
         parser.dstType == BranchType.DEVELOP
     }
+
+    @Unroll
+    def "processJob() allows push events to #branch"() {
+        given:
+        Map payload = [
+            ref: "refs/heads/${branch}",
+            before: "abc123",
+            after: "def456",
+            repository: [
+                name: "repo",
+                clone_url: "https://github.com/org/repo.git",
+                pushed_at: "2026-04-30T00:00:00Z",
+            ],
+            head_commit: [
+                id: "def456",
+                message: "Update ${branch}",
+                url: "https://github.com/org/repo/commit/def456",
+            ],
+            sender: [login: "dev", avatar_url: ""]
+        ]
+        WebhookParser parser = new WebhookParser(mockContext, payload)
+
+        when:
+        parser.setValues(false)
+
+        then:
+        parser.isPush == true
+        parser.dstType == expectedType
+        parser.shouldBeProcessed == true
+
+        where:
+        branch  | expectedType
+        "main"  | BranchType.MAIN
+        "trunk" | BranchType.TRUNK
+    }
 }

--- a/vars/ciorch.groovy
+++ b/vars/ciorch.groovy
@@ -29,6 +29,12 @@ def call(Map args = [:]) {
         echo "ciorch: ciorch.yml not found at ${configPath}, using defaults"
     }
 
+    // Allow preset vars (e.g. ciorch_node) to supply a default adapter when ciorch.yml
+    // does not specify one.
+    if (args.adapter && !config.buildAdapter) {
+        config.loadMap([build: [adapter: args.adapter]])
+    }
+
     // Initialize system call helper
     SystemCall system = new SystemCall(
         this,

--- a/vars/ciorch.groovy
+++ b/vars/ciorch.groovy
@@ -30,9 +30,9 @@ def call(Map args = [:]) {
     }
 
     // Allow preset vars (e.g. ciorch_node) to supply a default adapter when ciorch.yml
-    // does not specify one.
+    // does not specify one. Set the property directly to preserve all other loaded config.
     if (args.adapter && !config.buildAdapter) {
-        config.loadMap([build: [adapter: args.adapter]])
+        config.buildAdapter = args.adapter as String
     }
 
     // Initialize system call helper

--- a/vars/ciorch.groovy
+++ b/vars/ciorch.groovy
@@ -35,6 +35,12 @@ def call(Map args = [:]) {
         config.buildAdapter = args.adapter as String
     }
 
+    // Apply per-run command and version overrides from args (e.g. from ciorch_node(lint_command: ...))
+    if (args.lint_command)  config.lintCommand  = args.lint_command  as String
+    if (args.test_command)  config.testCommand  = args.test_command  as String
+    if (args.build_command) config.buildCommand = args.build_command as String
+    args.each { k, v -> if (k.toString().endsWith('_version')) config.toolVersions[k] = v }
+
     // Initialize system call helper
     SystemCall system = new SystemCall(
         this,

--- a/vars/ciorch.groovy
+++ b/vars/ciorch.groovy
@@ -39,7 +39,7 @@ def call(Map args = [:]) {
     if (args.lint_command)  config.lintCommand  = args.lint_command  as String
     if (args.test_command)  config.testCommand  = args.test_command  as String
     if (args.build_command) config.buildCommand = args.build_command as String
-    args.each { k, v -> if (k.toString().endsWith('_version')) config.toolVersions[k] = v }
+    args.each { k, v -> if (k.toString().endsWith('_version')) config.toolVersions[k.toString()] = v }
 
     // Initialize system call helper
     SystemCall system = new SystemCall(

--- a/vars/ciorch_cpp.groovy
+++ b/vars/ciorch_cpp.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch(args + [adapter: 'cpp'])
+    ciorch([adapter: 'cpp'] + args)
 }

--- a/vars/ciorch_cpp.groovy
+++ b/vars/ciorch_cpp.groovy
@@ -1,0 +1,3 @@
+def call(Map args = [:]) {
+    ciorch(args + [adapter: 'cpp'])
+}

--- a/vars/ciorch_cpp.groovy
+++ b/vars/ciorch_cpp.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch([adapter: 'cpp'] + args)
+    ciorch(args + [adapter: 'cpp'])
 }

--- a/vars/ciorch_csharp.groovy
+++ b/vars/ciorch_csharp.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch(args + [adapter: 'csharp'])
+    ciorch([adapter: 'csharp'] + args)
 }

--- a/vars/ciorch_csharp.groovy
+++ b/vars/ciorch_csharp.groovy
@@ -1,0 +1,3 @@
+def call(Map args = [:]) {
+    ciorch(args + [adapter: 'csharp'])
+}

--- a/vars/ciorch_csharp.groovy
+++ b/vars/ciorch_csharp.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch([adapter: 'csharp'] + args)
+    ciorch(args + [adapter: 'csharp'])
 }

--- a/vars/ciorch_go.groovy
+++ b/vars/ciorch_go.groovy
@@ -1,0 +1,3 @@
+def call(Map args = [:]) {
+    ciorch(args + [adapter: 'go'])
+}

--- a/vars/ciorch_go.groovy
+++ b/vars/ciorch_go.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch(args + [adapter: 'go'])
+    ciorch([adapter: 'go'] + args)
 }

--- a/vars/ciorch_go.groovy
+++ b/vars/ciorch_go.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch([adapter: 'go'] + args)
+    ciorch(args + [adapter: 'go'])
 }

--- a/vars/ciorch_java.groovy
+++ b/vars/ciorch_java.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch(args + [adapter: 'java'])
+    ciorch([adapter: 'java'] + args)
 }

--- a/vars/ciorch_java.groovy
+++ b/vars/ciorch_java.groovy
@@ -1,0 +1,3 @@
+def call(Map args = [:]) {
+    ciorch(args + [adapter: 'java'])
+}

--- a/vars/ciorch_java.groovy
+++ b/vars/ciorch_java.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch([adapter: 'java'] + args)
+    ciorch(args + [adapter: 'java'])
 }

--- a/vars/ciorch_node.groovy
+++ b/vars/ciorch_node.groovy
@@ -1,0 +1,3 @@
+def call(Map args = [:]) {
+    ciorch(args + [adapter: 'node'])
+}

--- a/vars/ciorch_node.groovy
+++ b/vars/ciorch_node.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch(args + [adapter: 'node'])
+    ciorch([adapter: 'node'] + args)
 }

--- a/vars/ciorch_node.groovy
+++ b/vars/ciorch_node.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch([adapter: 'node'] + args)
+    ciorch(args + [adapter: 'node'])
 }

--- a/vars/ciorch_php.groovy
+++ b/vars/ciorch_php.groovy
@@ -1,0 +1,3 @@
+def call(Map args = [:]) {
+    ciorch(args + [adapter: 'php'])
+}

--- a/vars/ciorch_php.groovy
+++ b/vars/ciorch_php.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch(args + [adapter: 'php'])
+    ciorch([adapter: 'php'] + args)
 }

--- a/vars/ciorch_php.groovy
+++ b/vars/ciorch_php.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch([adapter: 'php'] + args)
+    ciorch(args + [adapter: 'php'])
 }

--- a/vars/ciorch_python.groovy
+++ b/vars/ciorch_python.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch(args + [adapter: 'python'])
+    ciorch([adapter: 'python'] + args)
 }

--- a/vars/ciorch_python.groovy
+++ b/vars/ciorch_python.groovy
@@ -1,0 +1,3 @@
+def call(Map args = [:]) {
+    ciorch(args + [adapter: 'python'])
+}

--- a/vars/ciorch_python.groovy
+++ b/vars/ciorch_python.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch([adapter: 'python'] + args)
+    ciorch(args + [adapter: 'python'])
 }

--- a/vars/ciorch_rust.groovy
+++ b/vars/ciorch_rust.groovy
@@ -1,0 +1,3 @@
+def call(Map args = [:]) {
+    ciorch(args + [adapter: 'rust'])
+}

--- a/vars/ciorch_rust.groovy
+++ b/vars/ciorch_rust.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch(args + [adapter: 'rust'])
+    ciorch([adapter: 'rust'] + args)
 }

--- a/vars/ciorch_rust.groovy
+++ b/vars/ciorch_rust.groovy
@@ -1,3 +1,3 @@
 def call(Map args = [:]) {
-    ciorch([adapter: 'rust'] + args)
+    ciorch(args + [adapter: 'rust'])
 }


### PR DESCRIPTION
## Summary

- Implements all 9 language build adapters (Node, Go, PHP, Python, C#, Rust, Java, C++, Generic)
- Adds 8 preset `vars/ciorch_*.groovy` entry points and 8 `resources/matrix/*-standard.yml` presets
- Wires all adapters into `PipelineOrchestrator.BUILD_REGISTRY`
- 261 unit tests passing (up from 81 in 0.1.0)

## Adapters added

| Adapter | Toolchain |
|---|---|
| `node` | npm / yarn / pnpm |
| `go` | go modules + go vet / golangci-lint |
| `php` | Composer + phpcs + phpunit |
| `python` | pip / poetry / uv auto-detect + ruff/flake8 + pytest |
| `csharp` | dotnet restore/format/test/publish |
| `rust` | cargo clippy + fmt + test + build --release |
| `java` | Maven/Gradle auto-detect + checkstyle |
| `cpp` | CMake + make/ninja + cppcheck |
| `generic` | Arbitrary shell commands from ciorch.yml |

## Fixes included

- `lint_command` key normalised to snake_case across all adapters
- `lint()` now returns `false` on actual failures (was silently `true`)
- Null-context fallback executes the resolved command directly (not `eval "$CIORCH_CMD"`)
- `PythonAdapter` detects `python3` vs `python` at prepare-time
- `PythonAdapter` pip no-op no longer claims a false `dist/` artifact

## Test plan

- [x] `./gradlew :tests:unit:test` — 261/261 passing, 0 failures
- [ ] Smoke-test a consuming repo with `ciorch_node(payload: env.PAYLOAD)` in Jenkins sandbox