### PR TITLE
Superseded: Add clone traffic chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,3 +185,11 @@ Please open an issue before starting work on large features so we can discuss th
 ## License
 
 [MIT](LICENSE)
+
+---
+
+## Clone traffic
+
+![Clone traffic](https://raw.githubusercontent.com/nikolareljin/stats/main/charts/ci-orchestrator.svg)
+
+_Updated daily. Total and unique cloners over the last 14 days._


### PR DESCRIPTION
## Summary

- Add the clone traffic SVG chart from nikolareljin/stats to the README.

## Validation

- Verified the stats SVG exists at charts/ci-orchestrator.svg before updating the README.
- Ran git diff --check for the README change.